### PR TITLE
Don't default the start-date for the source or endpoint

### DIFF
--- a/digital_land/cli.py
+++ b/digital_land/cli.py
@@ -376,10 +376,7 @@ def endpoints_check_cmd(first_date, log_dir, endpoint_path, last_date):
 @collection_directory
 def add_source_endpoint_cmd(ctx, endpoint_url, organisation, collection_directory):
     """Add a new source/endpoint entry. Optional parameters are: source, attribution, collection, documentation-url,
-    licence, organisation, pipeline, status, plugin, parameters, start-date, end-date
-
-    Note, if unspecified, start-date is set to current date by default.
-    """
+    licence, organisation, pipeline, status, plugin, parameters, start-date, end-date"""
     entry = defaultdict(
         str,
         {ctx.args[i].strip("-"): ctx.args[i + 1] for i in range(0, len(ctx.args), 2)},

--- a/digital_land/update.py
+++ b/digital_land/update.py
@@ -80,15 +80,9 @@ def add_new_source_endpoint(entry, collection_directory):
     collection.save_csv()
 
 
-# If empty start-date set by user then no date should be set.
-# Otherwise set user-specified date or use current date
 def start_date(entry):
-    if "start-date" not in entry:
-        return date.today().strftime("%Y-%m-%d")
-
     if entry["start-date"]:
         return datetime.strptime(entry["start-date"], "%Y-%m-%d").date()
-
     return ""
 
 


### PR DESCRIPTION
Removed defaulting of the start-date in the collection as it's best left blank unless we have more information about when it was first published.