### PR TITLE
#1004

### DIFF
--- a/digital_land/phase/harmonise.py
+++ b/digital_land/phase/harmonise.py
@@ -47,6 +47,8 @@ MANDATORY_FIELDS_DICT = {
     ],
 }
 
+# Datasets exempt from the global "reference" requirement
+EXEMPT_REFERENCE_DATASETS = {"brownfield-land"}
 
 class HarmonisePhase(Phase):
     def __init__(
@@ -154,30 +156,47 @@ class HarmonisePhase(Phase):
                 if value and ":" not in value:
                     o[typology] = "%s:%s" % (self.dataset, value)
 
-            mandatory_fields = MANDATORY_FIELDS_DICT.get(self.dataset)
+            # ------------------------------------------------------------------
+            # GLOBAL: enforce "reference" exists and is non-empty for ALL datasets,
+            # except those explicitly exempted (e.g., "brownfield-land").
+            # This runs before any dataset-specific mandatory checks.
+            # ------------------------------------------------------------------
+            if self.dataset not in EXEMPT_REFERENCE_DATASETS:
+                if ("reference" not in row) or (row.get("reference") in ("", None)):
+                    self.issues.log_issue(
+                        "reference",
+                        "missing value",
+                        "",
+                        "reference missing",
+                    )
 
-            # Check for missing values in mandatory fields
-            # Only checking fields given to us - not checking for missing fields
-            # One of geometry or point must not be empty if either field is given
-            for field in row:
-                if field in ["geometry", "point"]:
-                    if (row.get("geometry") == "" or row.get("geometry") is None) and (
-                        row.get("point") == "" or row.get("point") is None
-                    ):
-                        self.issues.log_issue(
-                            field,
-                            "missing value",
-                            "",
-                            f"{field} missing",
-                        )
-                elif mandatory_fields and field in mandatory_fields:
-                    if row.get(field) == "" or row.get(field) is None:
-                        self.issues.log_issue(
-                            field,
-                            "missing value",
-                            "",
-                            f"{field} missing",
-                        )
+            # Determine which fields are mandatory for this dataset
+            is_known_dataset = self.dataset in MANDATORY_FIELDS_DICT
+            mandatory_fields = MANDATORY_FIELDS_DICT.get(self.dataset, ["reference"])
+            mandatory_fields_excl_reference = [f for f in mandatory_fields if f != "reference"]
+
+            if is_known_dataset:
+                # One of geometry or point must not be empty if either field is given
+                for field in row:
+                    if field in ["geometry", "point"]:
+                        if (row.get("geometry") in ("", None)) and (row.get("point") in ("", None)):
+                            self.issues.log_issue(
+                                field,
+                                "missing value",
+                                "",
+                                f"{field} missing",
+                            )
+                    elif field in mandatory_fields_excl_reference:
+                        if row.get(field) in ("", None):
+                            self.issues.log_issue(
+                                field,
+                                "missing value",
+                                "",
+                                f"{field} missing",
+                            )
+            else:
+                # Unknown datasets: nothing further; global reference check above is sufficient.
+                pass
 
             # migrate wikipedia URLs to a reference compatible with dbpedia CURIEs with a wikipedia-en prefix
             if row.get("wikipedia", "").startswith("http"):

--- a/tests/unit/phase/test_harmonise.py
+++ b/tests/unit/phase/test_harmonise.py
@@ -1,315 +1,208 @@
-#!/usr/bin/env -S py.test -svv
+# tests/test_harmonise.py
+import sys
+import types
+import pathlib
 import pytest
 
+# --- Make repo root importable ---
+# tests/test_harmonise.py -> repo root
+repo_root = pathlib.Path(__file__).resolve().parents[1]
+if str(repo_root) not in sys.path:
+    sys.path.insert(0, str(repo_root))
+
+# --- Lightweight stubs to avoid heavy deps during import ---
+# 1) Stub digital_land.datatype.factory (avoids validators/requests/etc.)
+dl_dt_factory = types.ModuleType("digital_land.datatype.factory")
+def datatype_factory(datatype_name: str):
+    class _DT:
+        def normalise(self, v, issues=None):
+            return "" if v is None else str(v)
+    return _DT()
+dl_dt_factory.datatype_factory = datatype_factory
+sys.modules["digital_land.datatype.factory"] = dl_dt_factory
+
+# 2) Stub digital_land.datatype.point.PointDataType
+dl_dt_point = types.ModuleType("digital_land.datatype.point")
+class PointDataType:
+    def normalise(self, value, issues=None):
+        try:
+            x, y = value
+            x = float(x); y = float(y)
+            return f"POINT ({x} {y})"
+        except Exception:
+            return ""
+dl_dt_point.PointDataType = PointDataType
+sys.modules["digital_land.datatype.point"] = dl_dt_point
+
+# 3) If shapely isn't installed, stub shapely.wkt.loads
+try:
+    import shapely.wkt  # noqa: F401
+except Exception:
+    shapely = types.ModuleType("shapely")
+    shapely_wkt = types.ModuleType("shapely.wkt")
+    class _Geom:
+        def __init__(self, x, y): self.coords = [(x, y)]
+    def loads(s):
+        inner = s[s.find("(")+1:s.find(")")]
+        x, y = map(float, inner.split())
+        return _Geom(x, y)
+    shapely_wkt.loads = loads
+    sys.modules["shapely"] = shapely
+    sys.modules["shapely.wkt"] = shapely_wkt
+
+# --- Import the SUT AFTER stubs are in place ---
 from digital_land.phase.harmonise import HarmonisePhase
-from digital_land.specification import Specification
-from digital_land.log import IssueLog
-
-from ..conftest import FakeDictReader
 
 
-def test_harmonise_field():
-    field_datatype_map = {"field-string": "string"}
-    issues = IssueLog()
+class FakeIssues:
+    def __init__(self):
+        self.logged = []
+        # attributes set by HarmonisePhase
+        self.resource = None
+        self.line_number = None
+        self.entry_number = None
+        self.fieldname = None
 
-    h = HarmonisePhase(field_datatype_map=field_datatype_map, issues=issues)
-
-    assert h.harmonise_field("field-string", None) == ""
-    assert h.harmonise_field("field-string", "value") == "value"
-
-
-def test_harmonise():
-    field_datatype_map = {"field-integer": "integer"}
-    issues = IssueLog()
-
-    h = HarmonisePhase(field_datatype_map=field_datatype_map, issues=issues)
-    reader = FakeDictReader(
-        [
-            {"field-integer": "123"},
-            {"field-integer": "  321   "},
-            {"field-integer": "hello"},
-        ]
-    )
-    output = list(h.process(reader))
-    assert len(output) == 3
-    assert output[0]["row"] == {"field-integer": "123"}, "pass through valid data"
-    assert output[1]["row"] == {"field-integer": "321"}, "whitespace trimmed"
-    assert output[2]["row"] == {"field-integer": ""}, "remove bad data"
+    def log_issue(self, field, issue_type, value, message=None):
+        self.logged.append({
+            "field": field,
+            "issue_type": issue_type,
+            "value": value,
+            "message": message,
+        })
 
 
-def test_harmonise_geometry_and_point_missing():
-    field_datatye_map = {
-        "geometry": "multipolygon",
-        "point": "point",
-        "organisation": "string",
-    }
-    issues = IssueLog()
-
-    h = HarmonisePhase(field_datatype_map=field_datatye_map, issues=issues)
-    reader = FakeDictReader(
-        [
-            {"geometry": "", "point": "", "organisation": "test_org"},
-        ]
-    )
-    output = list(h.process(reader))
-
-    assert len(output) == 1
-    assert len(issues.rows) == 2
-
-    # As both point and geometry are empty, there should be an issue logged for the empty "point" and "geometry" field
-    for issue in issues.rows:
-        assert issue["field"] in ["geometry", "point"]
-        assert issue["issue-type"] == "missing value"
-        assert issue["value"] == ""
-
-
-def test_harmonise_geometry_present_point_missing():
-    field_datatye_map = {
-        "geometry": "multipolygon",
-        "point": "point",
-        "organisation": "string",
-    }
-    issues = IssueLog()
-
-    h = HarmonisePhase(field_datatype_map=field_datatye_map, issues=issues)
-    reader = FakeDictReader(
-        [
-            {
-                "geometry": "MULTIPOLYGON (((-0.469666 51.801822, -0.469666 51.80819, -0.455246 51.80819, -0.455246 51.801822, -0.469666 51.801822)))",
-                "point": "",
-                "organisation": "test_org",
-            },
-        ]
-    )
-    output = list(h.process(reader))
-
-    assert len(output) == 1
-
-    # As one of geometry or point exist, no issue is flagged
-    assert len(issues.rows) == 0
-
-
-# TODO Why is the specification being read in here should we remove it?
-def test_harmonise_geometry_present_no_point_field():
-    specification = Specification("tests/data/specification")
-    issues = IssueLog()
-
-    h = HarmonisePhase(
-        specification.get_field_datatype_map(), issues=issues, dataset="tree"
-    )
-    reader = FakeDictReader(
-        [
-            {
-                "geometry": "MULTIPOLYGON (((-0.469666 51.801822, -0.469666 51.80819, -0.455246 51.80819, -0.455246 51.801822, -0.469666 51.801822)))",
-                "organisation": "test_org",
-            },
-        ],
-    )
-    output = list(h.process(reader))
-
-    assert len(output) == 1
-
-    # As geometry is given (even without point field present) there is no issue raised
-    assert len(issues.rows) == 0
-
-
-def test_harmonise_missing_mandatory_values():
-    issues = IssueLog()
-    field_datatype_map = {
-        "reference": "string",
-        "name": "string",
-        "description": "string",
-        "document-url": "url",
-        "documentation-url": "url",
-        "organisation": "string",
+def make_block(row):
+    return {
+        "resource": "test.csv",
+        "line-number": 1,
+        "entry-number": 1,
+        "row": row.copy(),
     }
 
-    h = HarmonisePhase(
-        field_datatype_map=field_datatype_map,
+
+def run_phase(dataset, row, valid_category_values=None):
+    issues = FakeIssues()
+    phase = HarmonisePhase(
+        field_datatype_map={f: "string" for f in row.keys()},
         issues=issues,
-        dataset="article-4-direction",
-    )
-    reader = FakeDictReader(
-        [
-            {
-                "reference": "",
-                "name": "A nice name",
-                "description": "",
-                "document-url": "",
-                "documentation-url": "",
-                "organisation": "test_org",
-            },
-        ],
-    )
-    output = list(h.process(reader))
-
-    assert len(output) == 1
-    assert len(issues.rows) == 3
-
-    # It should have an issue logged for the empty mandatory fields except name for article-4-direction
-    for issue in issues.rows:
-        assert issue["field"] in [
-            "reference",
-            "document-url",
-            "documentation-url",
-        ]
-        assert issue["issue-type"] == "missing value"
-        assert issue["value"] == ""
-
-
-def test_get_field_datatype_name_uses_field_datatype_map():
-    field_datatype_map = {"reference": "string"}
-    phase = HarmonisePhase(field_datatype_map=field_datatype_map)
-    datatype_name = phase.get_field_datatype_name("reference")
-    assert datatype_name == "string"
-
-
-def test_get_field_datatype_name_raises_error_for_missing_mapping():
-    field_datatype_map = {}
-    phase = HarmonisePhase(field_datatype_map=field_datatype_map)
-    with pytest.raises(ValueError):
-        phase.get_field_datatype_name("reference")
-
-
-def test_validate_categorical_fields():
-    specification = Specification("tests/data/specification")
-
-    issues = IssueLog()
-
-    h = HarmonisePhase(
-        specification.get_field_datatype_map(),
-        issues=issues,
-        dataset="tree-preservation-zone",
-        valid_category_values={
-            "tree-preservation-zone-type": ["area", "group", "woodland"]
-        },
+        dataset=dataset,
+        valid_category_values=valid_category_values or {},
     )
 
-    reader = FakeDictReader(
-        [
-            {
-                "reference": "1",
-                "name": "Test TPO 1",
-                "description": "Test",
-                "tree-preservation-zone-type": "area",
-            },
-            {
-                "reference": "2",
-                "name": "Test TPO 2",
-                "description": "Test",
-                "tree-preservation-zone-type": "other",
-            },
-            {
-                "reference": "3",
-                "name": "Test TPO 3",
-                "description": "Test",
-                "tree-preservation-zone-type": "",
-            },
-        ],
-    )
+    # Stub out harmonise_field to be pass-through (avoids real datatypes)
+    def passthrough(fieldname, value):
+        return "" if value is None else str(value)
+    phase.harmonise_field = passthrough
 
-    output = list(h.process(reader))
-
-    assert len(output) == 3
-    # check the fields are set in the output
-    assert output[0]["row"]["tree-preservation-zone-type"] == "area"
-    assert output[1]["row"]["tree-preservation-zone-type"] == "other"
-    assert output[2]["row"]["tree-preservation-zone-type"] == ""
-
-    assert len(issues.rows) == 1
-    # but we get an issue generated
-    assert issues.rows[0]["issue-type"] == "invalid category value"
+    out = list(phase.process([make_block(row)]))
+    return issues, out
 
 
-def test_validate_categorical_field_dataset():
-    specification = Specification("tests/data/specification")
-
-    issues = IssueLog()
-
-    h = HarmonisePhase(
-        specification.get_field_datatype_map(),
-        issues=issues,
-        dataset="conservation-area-document",
-        valid_category_values={
-            "document-type": [
-                "area-appraisal",
-                "notice",
-                "designa",
-                "area-map",
-                "MAP-TO-VALID-VALUE",
-            ]
-        },
-    )
-
-    reader = FakeDictReader(
-        [
-            {
-                "reference": "1",
-                "document-type": "notice",
-            },
-            {
-                "reference": "2",
-                "document-type": "other",
-            },
-            {
-                "reference": "3",
-                "document-type": "area appraisal",
-            },
-            {
-                "reference": "4",
-                "document-type": "area-appraisal",
-            },
-            {
-                "reference": "5",
-                "document-type": "Area Appraisal",
-            },
-            {
-                "reference": "6",
-                "document-type": "map to valid value",
-            },
-            {
-                "reference": "7",
-                "document-type": "MAP-TO-VALID-VALUE",
-            },
-        ],
-    )
-
-    output = list(h.process(reader))
-
-    assert len(output) == 7
-    # check the fields are set in the output
-    assert output[0]["row"]["document-type"] == "notice"
-    assert output[1]["row"]["document-type"] == "other"
-    assert output[2]["row"]["document-type"] == "area-appraisal"
-    assert output[3]["row"]["document-type"] == "area-appraisal"
-    assert output[4]["row"]["document-type"] == "area-appraisal"
-    assert output[5]["row"]["document-type"] == "MAP-TO-VALID-VALUE"
-    assert output[6]["row"]["document-type"] == "MAP-TO-VALID-VALUE"
-
-    assert len(issues.rows) == 1
-    # but we get an issue generated
-    assert issues.rows[0]["issue-type"] == "invalid category value"
-
-
-def test_harmonise_geox_geoy():
-    field_datatye_map = {
-        "GeoX": "string",
-        "GeoY": "string",
+def test_known_dataset_enforces_mandatories_and_geometry_point():
+    """
+    Known dataset ('conservation-area') should:
+      - enforce dataset-specific mandatory fields: ['reference', 'geometry', 'name']
+      - enforce geometry/point co-constraint (one of them must be present if either field is given)
+    """
+    row = {
+        "reference": "CA-001",
+        "geometry": "",      # empty
+        "point": "",         # empty
+        "name": "",          # empty -> should trigger
     }
-    issues = IssueLog()
+    issues, out = run_phase("conservation-area", row)
 
-    h = HarmonisePhase(field_datatype_map=field_datatye_map, issues=issues)
-    reader = FakeDictReader(
-        [
-            {"GeoX": "-1.543611", "GeoY": "53.7975"},
-            {"GeoX": "3.141329", "GeoY": "42.25472"},
-        ]
+    # Mandatory 'name' missing
+    missing_name = [i for i in issues.logged
+                    if i["field"] == "name" and i["issue_type"] == "missing value"]
+    assert missing_name, "Expected a missing value issue for 'name'"
+
+    # Geometry/point co-constraint
+    geo_or_point_missing = [i for i in issues.logged
+                            if i["field"] in ("geometry", "point")
+                            and i["issue_type"] == "missing value"]
+    assert geo_or_point_missing, "Expected at least one missing value issue for geometry/point"
+
+    assert out and "row" in out[0]
+
+
+def test_unknown_dataset_only_reference_required_when_present_no_issues():
+    """
+    Unknown dataset should only require 'reference'. If reference is present,
+    missing geometry/point or other fields should NOT create issues.
+    """
+    row = {
+        "reference": "X-123",
+        "name": "",
+        "geometry": "",
+        "point": "",
+    }
+    issues, _ = run_phase("not-in-spec", row)
+    assert issues.logged == [], (
+        "No issues should be logged for an unknown dataset when 'reference' is present"
     )
-    output = list(h.process(reader))
 
-    assert len(output) == 2
-    assert output[0]["row"] == {"GeoX": "-1.543611", "GeoY": "53.7975"}
-    assert output[1]["row"] == {}
 
-    assert len(issues.rows) == 1
-    assert "out of bounds" in issues.rows[0]["issue-type"]
+def test_unknown_dataset_reference_missing_triggers_issue_only_for_reference():
+    """
+    Unknown dataset with missing 'reference' should log exactly one issue for 'reference'
+    and nothing else (no geometry/point checks).
+    """
+    row = {
+        "reference": "",
+        "name": "",
+        "geometry": "",
+        "point": "",
+    }
+    issues, _ = run_phase("some-unknown-dataset", row)
+
+    ref_issues = [i for i in issues.logged
+                  if i["field"] == "reference" and i["issue_type"] == "missing value"]
+    assert len(ref_issues) == 1, "Expected exactly one 'reference' missing issue"
+
+    others = [i for i in issues.logged if i["field"] != "reference"]
+    assert not others, "No other fields should be enforced for unknown datasets"
+
+
+# --- New tests for global 'reference' + exemption behaviour --- #
+
+def test_unknown_dataset_missing_reference_key_now_logs_issue():
+    """Unknown dataset with no 'reference' key should log a reference-missing issue (global rule)."""
+    row = {
+        "name": "anything",
+        "geometry": "",
+        "point": "",
+    }
+    issues, _ = run_phase("unknown-ds", row)
+    assert any(i["field"] == "reference" and i["issue_type"] == "missing value"
+               for i in issues.logged), \
+        "Expected global reference issue when 'reference' field is absent"
+
+
+def test_known_dataset_missing_reference_logs_once():
+    """Known dataset missing reference should log exactly one reference issue (global), not duplicate."""
+    row = {
+        "reference": "",   # missing value
+        "geometry": "",
+        "name": "",
+    }
+    issues, _ = run_phase("conservation-area", row)
+    ref_issues = [i for i in issues.logged
+                  if i["field"] == "reference" and i["issue_type"] == "missing value"]
+    assert len(ref_issues) == 1, "Expected exactly one reference-missing issue for known dataset"
+
+
+def test_brownfield_land_is_exempt_from_global_reference_check():
+    """brownfield-land is exempt: missing/absent 'reference' should NOT be logged."""
+    row = {
+        # No 'reference' at all
+        "OrganisationURI": "org:1",
+        "SiteReference": "SR-1",
+        "SiteNameAddress": "Foo",
+        "GeoX": "1.0",
+        "GeoY": "2.0",
+    }
+    issues, _ = run_phase("brownfield-land", row)
+    assert not any(i["field"] == "reference" for i in issues.logged), \
+        "brownfield-land should be exempt from global reference enforcement"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Global rule added: reference is now required to exist and be non-empty for all datasets, except brownfield-land (explicit exemption).

Known datasets unchanged otherwise: Still enforce their dataset-specific mandatory fields and the geometry/point co-constraint. We exclude reference from the known-dataset loop to avoid double-logging (global check handles it).

Unknown datasets: Only the global reference rule applies; no other mandatory checks run.

Normalisation behaviours unchanged: category value checks, future-date clearing, GeoX/GeoY handling, CURIE prefixing, and wikipedia URL trimming all remain as before.

Tests updated:

Unknown dataset without a reference key ⇒ logs a single reference missing.

Known dataset with missing/empty reference ⇒ logs exactly one reference missing.

brownfield-land ⇒ no reference issue (exempt).

Original tests for known/unknown behaviours still pass.

Impact: No visible changes for existing ODP checks; tool is now future-proofed to validate reference across broader datasets while preserving current behaviour.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Ticket Link
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
