### PR TITLE
Updated org dataset lookup test

### DIFF
--- a/digital_land/expectations/operations/csv.py
+++ b/digital_land/expectations/operations/csv.py
@@ -558,82 +558,109 @@ def check_field_is_within_range_by_dataset_org(
     min_col = f'"{min_field}"'
     max_col = f'"{max_field}"'
     value_col = f'"{field_name}"'
+    dataset_alias_map = dataset_aliases or {}
 
-    exception_dataset_map = dataset_aliases or {}
-    exception_mapping_rows = [
-        f"({_sql_string(str(lookup_key).strip())}, {_sql_string(str(range_value).strip())})"
-        for lookup_key, range_values in exception_dataset_map.items()
-        for range_value in range_values
-        if str(lookup_key).strip() and str(range_value).strip()
+    # Flattens dataset_aliases dict into a VALUES clause for SQL CTE.
+    # [("statistical-geography", "ward"), ...]
+    dataset_alias_rows = [
+        f"({_sql_string(str(dataset).strip())}, {_sql_string(str(alias).strip())})"
+        for dataset, aliases in dataset_alias_map.items()
+        for alias in aliases
+        if str(dataset).strip() and str(alias).strip()
     ]
 
-    mapping_cte = (
-        ",exception_mappings AS (SELECT * FROM (VALUES"
-        + ",".join(exception_mapping_rows)
-        + ") AS m(lookup_key_0, range_key_0))"
-        if exception_mapping_rows
-        else ""
-    )
+    # When dataset_aliases is empty, we still need a dummy CTE to avoid SQL errors in the main query.
+    # Creates a CTE for alias mapping with rows e.g.:
+    # statistical-geography | ward
+    # statistical-geography | region
+    if dataset_alias_rows:
+        values_clause = ",".join(dataset_alias_rows)
+    else:
+        values_clause = "(NULL, NULL)"
 
-    match_condition = (
-        """CASE WHEN EXISTS
-                    (SELECT 1 FROM exception_mappings em WHERE em.lookup_key_0 = l.lookup_key_0)
-                THEN EXISTS
-                    (SELECT 1 FROM exception_mappings em WHERE em.lookup_key_0 = l.lookup_key_0
-                            AND em.range_key_0 = r.range_key_0)
-                ELSE l.lookup_key_0 = r.range_key_0 END"""
-        if exception_mapping_rows
-        else "l.lookup_key_0 = r.range_key_0"
-    )
-
-    result = conn.execute(
-        f"""
-        WITH ranges AS (
-            SELECT
-                TRY_CAST({min_col} AS BIGINT) AS min_value,
-                TRY_CAST({max_col} AS BIGINT) AS max_value,
-                TRIM(COALESCE({range_dataset_col}, '')) AS range_key_0,
-                                TRIM(COALESCE("organisation", '')) AS range_key_1
-            FROM {_read_csv(external_file)}
-            WHERE TRY_CAST({min_col} AS BIGINT) IS NOT NULL
-              AND TRY_CAST({max_col} AS BIGINT) IS NOT NULL
-              AND TRIM(COALESCE({range_dataset_col}, '')) != ''
-                            AND TRIM(COALESCE("organisation", '')) != ''
-        )
-        {mapping_cte},
-        source_rows AS (
-            SELECT
-                ROW_NUMBER() OVER () + 1 AS line_number,
-                *
-            FROM {_read_csv(file_path)}
-        ),
-        lookup_rows AS (
-            SELECT
-                src.line_number,
-                TRY_CAST(src.{value_col} AS BIGINT) AS value,
-                TRIM(COALESCE(src.{lookup_dataset_col}, '')) AS lookup_key_0,
-                TRIM(COALESCE(src."organisation", '')) AS lookup_key_1
-            FROM source_rows src
-            WHERE TRY_CAST(src.{value_col} AS BIGINT) IS NOT NULL
-              AND TRIM(COALESCE(src.{lookup_dataset_col}, '')) != ''
-              AND TRIM(COALESCE(src."organisation", '')) != ''{lookup_clause}
-        )
+    dataset_alias_cte = f"""
+    , dataset_aliases_map AS (
         SELECT
-            line_number,
-            value,
-            lookup_key_0,
-            lookup_key_1
-        FROM lookup_rows l
-        WHERE NOT EXISTS (
-            SELECT 1
-            FROM ranges r
-            WHERE l.value BETWEEN r.min_value AND r.max_value
-                  AND {match_condition}
-                  AND l.lookup_key_1 = r.range_key_1
+            CAST(dataset AS VARCHAR) AS dataset,
+            CAST(alias AS VARCHAR) AS alias
+        FROM (VALUES
+            {values_clause}
+        ) AS m(dataset, alias)
+        WHERE dataset IS NOT NULL
+    )
+    """
+
+    query = f"""
+    WITH
+
+    ranges AS (
+        SELECT
+            TRY_CAST({min_col} AS BIGINT) AS min_value,
+            TRY_CAST({max_col} AS BIGINT) AS max_value,
+            TRIM(COALESCE({range_dataset_col}, '')) AS range_dataset,
+            TRIM(COALESCE("organisation", '')) AS range_org
+        FROM {_read_csv(external_file)}
+        WHERE TRY_CAST({min_col} AS BIGINT) IS NOT NULL
+        AND TRY_CAST({max_col} AS BIGINT) IS NOT NULL
+        AND TRIM(COALESCE({range_dataset_col}, '')) != ''
+        AND TRIM(COALESCE("organisation", '')) != ''
+    )
+
+    {dataset_alias_cte}
+
+    , source_rows AS (
+        SELECT
+            ROW_NUMBER() OVER () + 1 AS line_number,
+            *
+        FROM {_read_csv(file_path)}
+    )
+
+    , lookup_rows AS (
+        SELECT
+            src.line_number,
+            TRY_CAST(src.{value_col} AS BIGINT) AS value,
+            TRIM(COALESCE(src.{lookup_dataset_col}, '')) AS lookup_dataset,
+            TRIM(COALESCE(src."organisation", '')) AS lookup_org
+        FROM source_rows src
+        WHERE TRY_CAST(src.{value_col} AS BIGINT) IS NOT NULL
+        AND TRIM(COALESCE(src.{lookup_dataset_col}, '')) != ''
+        AND TRIM(COALESCE(src."organisation", '')) != ''
+        {lookup_clause}
+    )
+
+    SELECT
+        l.line_number,
+        l.value,
+        l.lookup_dataset,
+        l.lookup_org
+    FROM lookup_rows l
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM ranges r
+        WHERE l.value BETWEEN r.min_value AND r.max_value
+        AND l.lookup_org = r.range_org
+
+        AND (
+            EXISTS (
+                SELECT 1
+                FROM dataset_aliases_map dam
+                WHERE dam.dataset = l.lookup_dataset
+                AND dam.alias = r.range_dataset
+            )
+            OR (
+                NOT EXISTS (
+                    SELECT 1
+                    FROM dataset_aliases_map dam
+                    WHERE dam.dataset = l.lookup_dataset
+                )
+                AND l.lookup_dataset = r.range_dataset
+            )
         )
-        ORDER BY line_number
-        """
-    ).fetchall()
+    )
+    ORDER BY l.line_number
+    """
+
+    result = conn.execute(query).fetchall()
 
     out_of_range_rows = []
     for row in result:

--- a/digital_land/expectations/operations/csv.py
+++ b/digital_land/expectations/operations/csv.py
@@ -507,9 +507,9 @@ def check_field_is_within_range_by_dataset_org(
     2. organisation -> organisation
 
     Edge case: some lookup datasets map to more than one valid range dataset.
-    When the lookup dataset value appears in dataset_aliases, the direct
-    dataset-to-dataset match is replaced by the configured list of allowed
-    range dataset values.
+    When the lookup value matches a key in dataset_aliases, the value is checked
+    against the configured list of allowed range datasets instead of requiring a
+    direct dataset-to-dataset match.
 
     Args:
         conn: duckdb connection
@@ -575,34 +575,15 @@ def check_field_is_within_range_by_dataset_org(
         else ""
     )
 
-    expected_range_keys_cte = (
-        """
-        ,expected_range_keys AS (
-            SELECT
-                l.lookup_key_0,
-                l.lookup_key_0 AS range_key_0
-            FROM lookup_rows l
-            WHERE NOT EXISTS (
-                SELECT 1
-                FROM exception_mappings em
-                WHERE em.lookup_key_0 = l.lookup_key_0
-            )
-            UNION ALL
-            SELECT
-                lookup_key_0,
-                range_key_0
-            FROM exception_mappings
-        )
-        """
+    match_condition = (
+        """CASE WHEN EXISTS
+                    (SELECT 1 FROM exception_mappings em WHERE em.lookup_key_0 = l.lookup_key_0)
+                THEN EXISTS
+                    (SELECT 1 FROM exception_mappings em WHERE em.lookup_key_0 = l.lookup_key_0
+                            AND em.range_key_0 = r.range_key_0)
+                ELSE l.lookup_key_0 = r.range_key_0 END"""
         if exception_mapping_rows
-        else """
-        ,expected_range_keys AS (
-            SELECT
-                lookup_key_0,
-                lookup_key_0 AS range_key_0
-            FROM lookup_rows
-        )
-        """
+        else "l.lookup_key_0 = r.range_key_0"
     )
 
     result = conn.execute(
@@ -637,7 +618,6 @@ def check_field_is_within_range_by_dataset_org(
               AND TRIM(COALESCE(src.{lookup_dataset_col}, '')) != ''
               AND TRIM(COALESCE(src."organisation", '')) != ''{lookup_clause}
         )
-        {expected_range_keys_cte}
         SELECT
             line_number,
             value,
@@ -647,11 +627,9 @@ def check_field_is_within_range_by_dataset_org(
         WHERE NOT EXISTS (
             SELECT 1
             FROM ranges r
-            JOIN expected_range_keys erk
-              ON erk.lookup_key_0 = l.lookup_key_0
-             AND erk.range_key_0 = r.range_key_0
             WHERE l.value BETWEEN r.min_value AND r.max_value
-              AND l.lookup_key_1 = r.range_key_1
+                  AND {match_condition}
+                  AND l.lookup_key_1 = r.range_key_1
         )
         ORDER BY line_number
         """

--- a/digital_land/expectations/operations/csv.py
+++ b/digital_land/expectations/operations/csv.py
@@ -497,7 +497,7 @@ def check_field_is_within_range_by_dataset_org(
     lookup_dataset_field: str,
     range_dataset_field: str,
     rules: dict = None,
-    prefix_datasets: dict = None,
+    dataset_aliases: dict = None,
 ):
     """
     Check field values are within ranges matched by dataset field and organisation.
@@ -505,6 +505,11 @@ def check_field_is_within_range_by_dataset_org(
     Matching is fixed to two keys:
     1. lookup_dataset_field -> range_dataset_field
     2. organisation -> organisation
+
+    Edge case: some lookup datasets map to more than one valid range dataset.
+    When the lookup dataset value appears in dataset_aliases, the direct
+    dataset-to-dataset match is replaced by the configured list of allowed
+    range dataset values.
 
     Args:
         conn: duckdb connection
@@ -523,8 +528,8 @@ def check_field_is_within_range_by_dataset_org(
              {"lookup_rules": {"prefix": "conservationarea"}}
              {"lookup_rules": {"organisation": {"op": "in", "value": ["orgA", "orgB"]}}}
              Use operators like != and not in when you want to exclude rows.
-         prefix_datasets: optional mapping of lookup prefix
-             values to allowed fallback range dataset values.
+         dataset_aliases: optional mapping of lookup dataset values
+             to allowed range dataset values.
              Example:
              {"statistical-geography": ["ward", "region"]}
     """
@@ -554,7 +559,7 @@ def check_field_is_within_range_by_dataset_org(
     max_col = f'"{max_field}"'
     value_col = f'"{field_name}"'
 
-    exception_dataset_map = prefix_datasets or {}
+    exception_dataset_map = dataset_aliases or {}
     exception_mapping_rows = [
         f"({_sql_string(str(lookup_key).strip())}, {_sql_string(str(range_value).strip())})"
         for lookup_key, range_values in exception_dataset_map.items()
@@ -570,15 +575,34 @@ def check_field_is_within_range_by_dataset_org(
         else ""
     )
 
-    match_condition = (
-        """CASE WHEN EXISTS
-                    (SELECT 1 FROM exception_mappings em WHERE em.lookup_key_0 = l.lookup_key_0)
-                THEN EXISTS
-                    (SELECT 1 FROM exception_mappings em WHERE em.lookup_key_0 = l.lookup_key_0
-                            AND em.range_key_0 = r.range_key_0)
-                ELSE l.lookup_key_0 = r.range_key_0 END"""
+    expected_range_keys_cte = (
+        """
+        ,expected_range_keys AS (
+            SELECT
+                l.lookup_key_0,
+                l.lookup_key_0 AS range_key_0
+            FROM lookup_rows l
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM exception_mappings em
+                WHERE em.lookup_key_0 = l.lookup_key_0
+            )
+            UNION ALL
+            SELECT
+                lookup_key_0,
+                range_key_0
+            FROM exception_mappings
+        )
+        """
         if exception_mapping_rows
-        else "l.lookup_key_0 = r.range_key_0"
+        else """
+        ,expected_range_keys AS (
+            SELECT
+                lookup_key_0,
+                lookup_key_0 AS range_key_0
+            FROM lookup_rows
+        )
+        """
     )
 
     result = conn.execute(
@@ -613,6 +637,7 @@ def check_field_is_within_range_by_dataset_org(
               AND TRIM(COALESCE(src.{lookup_dataset_col}, '')) != ''
               AND TRIM(COALESCE(src."organisation", '')) != ''{lookup_clause}
         )
+        {expected_range_keys_cte}
         SELECT
             line_number,
             value,
@@ -622,9 +647,11 @@ def check_field_is_within_range_by_dataset_org(
         WHERE NOT EXISTS (
             SELECT 1
             FROM ranges r
+            JOIN expected_range_keys erk
+              ON erk.lookup_key_0 = l.lookup_key_0
+             AND erk.range_key_0 = r.range_key_0
             WHERE l.value BETWEEN r.min_value AND r.max_value
-                  AND {match_condition}
-                  AND l.lookup_key_1 = r.range_key_1
+              AND l.lookup_key_1 = r.range_key_1
         )
         ORDER BY line_number
         """

--- a/digital_land/expectations/operations/csv.py
+++ b/digital_land/expectations/operations/csv.py
@@ -506,11 +506,6 @@ def check_field_is_within_range_by_dataset_org(
     1. lookup_dataset_field -> range_dataset_field
     2. organisation -> organisation
 
-    Edge case: some lookup datasets map to more than one valid range dataset.
-    When the lookup value matches a key in dataset_aliases, the value is checked
-    against the configured list of allowed range datasets instead of requiring a
-    direct dataset-to-dataset match.
-
     Args:
         conn: duckdb connection
         file_path: path to the CSV file containing fields to validate
@@ -573,86 +568,85 @@ def check_field_is_within_range_by_dataset_org(
         values_clause = ",".join(dataset_alias_rows)
     else:
         values_clause = "(NULL, NULL)"
+    result = conn.execute(
+        f"""
+        WITH
 
-    query = f"""
-    WITH
+        ranges AS (
+            SELECT
+                TRY_CAST({min_col} AS BIGINT) AS min_value,
+                TRY_CAST({max_col} AS BIGINT) AS max_value,
+                TRIM(COALESCE({range_dataset_col}, '')) AS range_dataset,
+                TRIM(COALESCE("organisation", '')) AS range_org
+            FROM {_read_csv(external_file)}
+            WHERE TRY_CAST({min_col} AS BIGINT) IS NOT NULL
+            AND TRY_CAST({max_col} AS BIGINT) IS NOT NULL
+            AND TRIM(COALESCE({range_dataset_col}, '')) != ''
+            AND TRIM(COALESCE("organisation", '')) != ''
+        ),
 
-    ranges AS (
+        dataset_aliases_map AS (
+            SELECT
+                CAST(dataset AS VARCHAR) AS dataset,
+                CAST(alias AS VARCHAR) AS alias
+            FROM (VALUES
+                {values_clause}
+            ) AS m(dataset, alias)
+            WHERE dataset IS NOT NULL
+        ),
+
+        source_rows AS (
+            SELECT
+                ROW_NUMBER() OVER () + 1 AS line_number,
+                *
+            FROM {_read_csv(file_path)}
+        ),
+
+        lookup_rows AS (
+            SELECT
+                src.line_number,
+                TRY_CAST(src.{value_col} AS BIGINT) AS value,
+                TRIM(COALESCE(src.{lookup_dataset_col}, '')) AS lookup_dataset,
+                TRIM(COALESCE(src."organisation", '')) AS lookup_org
+            FROM source_rows src
+            WHERE TRY_CAST(src.{value_col} AS BIGINT) IS NOT NULL
+            AND TRIM(COALESCE(src.{lookup_dataset_col}, '')) != ''
+            AND TRIM(COALESCE(src."organisation", '')) != ''
+            {lookup_clause}
+        )
+
         SELECT
-            TRY_CAST({min_col} AS BIGINT) AS min_value,
-            TRY_CAST({max_col} AS BIGINT) AS max_value,
-            TRIM(COALESCE({range_dataset_col}, '')) AS range_dataset,
-            TRIM(COALESCE("organisation", '')) AS range_org
-        FROM {_read_csv(external_file)}
-        WHERE TRY_CAST({min_col} AS BIGINT) IS NOT NULL
-        AND TRY_CAST({max_col} AS BIGINT) IS NOT NULL
-        AND TRIM(COALESCE({range_dataset_col}, '')) != ''
-        AND TRIM(COALESCE("organisation", '')) != ''
-    ),
+            l.line_number,
+            l.value,
+            l.lookup_dataset,
+            l.lookup_org
+        FROM lookup_rows l
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM ranges r
+            WHERE l.value BETWEEN r.min_value AND r.max_value
+            AND l.lookup_org = r.range_org
 
-    dataset_aliases_map AS (
-        SELECT
-            CAST(dataset AS VARCHAR) AS dataset,
-            CAST(alias AS VARCHAR) AS alias
-        FROM (VALUES
-            {values_clause}
-        ) AS m(dataset, alias)
-        WHERE dataset IS NOT NULL
-    ),
-
-    source_rows AS (
-        SELECT
-            ROW_NUMBER() OVER () + 1 AS line_number,
-            *
-        FROM {_read_csv(file_path)}
-    ),
-
-    lookup_rows AS (
-        SELECT
-            src.line_number,
-            TRY_CAST(src.{value_col} AS BIGINT) AS value,
-            TRIM(COALESCE(src.{lookup_dataset_col}, '')) AS lookup_dataset,
-            TRIM(COALESCE(src."organisation", '')) AS lookup_org
-        FROM source_rows src
-        WHERE TRY_CAST(src.{value_col} AS BIGINT) IS NOT NULL
-        AND TRIM(COALESCE(src.{lookup_dataset_col}, '')) != ''
-        AND TRIM(COALESCE(src."organisation", '')) != ''
-        {lookup_clause}
-    )
-
-    SELECT
-        l.line_number,
-        l.value,
-        l.lookup_dataset,
-        l.lookup_org
-    FROM lookup_rows l
-    WHERE NOT EXISTS (
-        SELECT 1
-        FROM ranges r
-        WHERE l.value BETWEEN r.min_value AND r.max_value
-        AND l.lookup_org = r.range_org
-
-        AND (
-            EXISTS (
-                SELECT 1
-                FROM dataset_aliases_map dam
-                WHERE dam.dataset = l.lookup_dataset
-                AND dam.alias = r.range_dataset
-            )
-            OR (
-                NOT EXISTS (
+            AND (
+                EXISTS (
                     SELECT 1
                     FROM dataset_aliases_map dam
                     WHERE dam.dataset = l.lookup_dataset
+                    AND dam.alias = r.range_dataset
                 )
-                AND l.lookup_dataset = r.range_dataset
+                OR (
+                    NOT EXISTS (
+                        SELECT 1
+                        FROM dataset_aliases_map dam
+                        WHERE dam.dataset = l.lookup_dataset
+                    )
+                    AND l.lookup_dataset = r.range_dataset
+                )
             )
         )
-    )
-    ORDER BY l.line_number
-    """
-
-    result = conn.execute(query).fetchall()
+        ORDER BY l.line_number
+        """
+    ).fetchall()
 
     out_of_range_rows = []
     for row in result:

--- a/digital_land/expectations/operations/csv.py
+++ b/digital_land/expectations/operations/csv.py
@@ -570,14 +570,14 @@ def check_field_is_within_range_by_dataset_org(
     ]
 
     # When dataset_aliases is empty, we still need a dummy CTE to avoid SQL errors in the main query.
-    # Creates a CTE for alias mapping with rows e.g.:
-    # statistical-geography | ward
-    # statistical-geography | region
     if dataset_alias_rows:
         values_clause = ",".join(dataset_alias_rows)
     else:
         values_clause = "(NULL, NULL)"
 
+    # Creates a CTE for alias mapping with rows e.g.:
+    # statistical-geography | ward
+    # statistical-geography | region
     dataset_alias_cte = f"""
     , dataset_aliases_map AS (
         SELECT

--- a/digital_land/expectations/operations/csv.py
+++ b/digital_land/expectations/operations/csv.py
@@ -497,6 +497,7 @@ def check_field_is_within_range_by_dataset_org(
     lookup_dataset_field: str,
     range_dataset_field: str,
     rules: dict = None,
+    prefix_datasets: dict = None,
 ):
     """
     Check field values are within ranges matched by dataset field and organisation.
@@ -514,14 +515,18 @@ def check_field_is_within_range_by_dataset_org(
         max_field: the column name for the range maximum
         lookup_dataset_field: dataset column name in file_path
         range_dataset_field: dataset column name in external_file
-        rules: optional dict controlling subset selection on lookup rows.
-               Supported keys:
-               - lookup_rules: dict or list[dict] of structured conditions.
-                 Fields in one dict are AND'ed; multiple dicts are OR'ed.
-               Examples:
-               {"lookup_rules": {"prefix": "conservationarea"}}
-               {"lookup_rules": {"organisation": {"op": "in", "value": ["orgA", "orgB"]}}}
-               Use operators like != and not in when you want to exclude rows.
+         rules: optional dict controlling subset selection on lookup rows.
+             Supported keys:
+             - lookup_rules: dict or list[dict] of structured conditions.
+               Fields in one dict are AND'ed; multiple dicts are OR'ed.
+             Examples:
+             {"lookup_rules": {"prefix": "conservationarea"}}
+             {"lookup_rules": {"organisation": {"op": "in", "value": ["orgA", "orgB"]}}}
+             Use operators like != and not in when you want to exclude rows.
+         prefix_datasets: optional mapping of lookup prefix
+             values to allowed fallback range dataset values.
+             Example:
+             {"statistical-geography": ["ward", "region"]}
     """
     file_columns = _get_csv_columns(conn, file_path)
     rules = rules or {}
@@ -549,6 +554,33 @@ def check_field_is_within_range_by_dataset_org(
     max_col = f'"{max_field}"'
     value_col = f'"{field_name}"'
 
+    exception_dataset_map = prefix_datasets or {}
+    exception_mapping_rows = [
+        f"({_sql_string(str(lookup_key).strip())}, {_sql_string(str(range_value).strip())})"
+        for lookup_key, range_values in exception_dataset_map.items()
+        for range_value in range_values
+        if str(lookup_key).strip() and str(range_value).strip()
+    ]
+
+    mapping_cte = (
+        ",exception_mappings AS (SELECT * FROM (VALUES"
+        + ",".join(exception_mapping_rows)
+        + ") AS m(lookup_key_0, range_key_0))"
+        if exception_mapping_rows
+        else ""
+    )
+
+    match_condition = (
+        """CASE WHEN EXISTS
+                    (SELECT 1 FROM exception_mappings em WHERE em.lookup_key_0 = l.lookup_key_0)
+                THEN EXISTS
+                    (SELECT 1 FROM exception_mappings em WHERE em.lookup_key_0 = l.lookup_key_0
+                            AND em.range_key_0 = r.range_key_0)
+                ELSE l.lookup_key_0 = r.range_key_0 END"""
+        if exception_mapping_rows
+        else "l.lookup_key_0 = r.range_key_0"
+    )
+
     result = conn.execute(
         f"""
         WITH ranges AS (
@@ -562,7 +594,8 @@ def check_field_is_within_range_by_dataset_org(
               AND TRY_CAST({max_col} AS BIGINT) IS NOT NULL
               AND TRIM(COALESCE({range_dataset_col}, '')) != ''
                             AND TRIM(COALESCE("organisation", '')) != ''
-        ),
+        )
+        {mapping_cte},
         source_rows AS (
             SELECT
                 ROW_NUMBER() OVER () + 1 AS line_number,
@@ -590,7 +623,7 @@ def check_field_is_within_range_by_dataset_org(
             SELECT 1
             FROM ranges r
             WHERE l.value BETWEEN r.min_value AND r.max_value
-                  AND l.lookup_key_0 = r.range_key_0
+                  AND {match_condition}
                   AND l.lookup_key_1 = r.range_key_1
         )
         ORDER BY line_number

--- a/digital_land/expectations/operations/csv.py
+++ b/digital_land/expectations/operations/csv.py
@@ -515,18 +515,18 @@ def check_field_is_within_range_by_dataset_org(
         max_field: the column name for the range maximum
         lookup_dataset_field: dataset column name in file_path
         range_dataset_field: dataset column name in external_file
-         rules: optional dict controlling subset selection on lookup rows.
-             Supported keys:
-             - lookup_rules: dict or list[dict] of structured conditions.
-               Fields in one dict are AND'ed; multiple dicts are OR'ed.
-             Examples:
-             {"lookup_rules": {"prefix": "conservationarea"}}
-             {"lookup_rules": {"organisation": {"op": "in", "value": ["orgA", "orgB"]}}}
-             Use operators like != and not in when you want to exclude rows.
-         dataset_aliases: optional mapping of lookup dataset values
-             to allowed range dataset values.
-             Example:
-             {"statistical-geography": ["ward", "region"]}
+        rules: optional dict controlling subset selection on lookup rows.
+            Supported keys:
+            - lookup_rules: dict or list[dict] of structured conditions.
+            Fields in one dict are AND'ed; multiple dicts are OR'ed.
+            Examples:
+            {"lookup_rules": {"prefix": "conservationarea"}}
+            {"lookup_rules": {"organisation": {"op": "in", "value": ["orgA", "orgB"]}}}
+            Use operators like != and not in when you want to exclude rows.
+        dataset_aliases: optional mapping of lookup dataset values
+            to allowed range dataset values.
+            Example:
+            {"statistical-geography": ["ward", "region"]}
     """
     file_columns = _get_csv_columns(conn, file_path)
     rules = rules or {}
@@ -570,9 +570,7 @@ def check_field_is_within_range_by_dataset_org(
         values_clause = "(NULL, NULL)"
     result = conn.execute(
         f"""
-        WITH
-
-        ranges AS (
+        WITH ranges AS (
             SELECT
                 TRY_CAST({min_col} AS BIGINT) AS min_value,
                 TRY_CAST({max_col} AS BIGINT) AS max_value,
@@ -611,8 +609,7 @@ def check_field_is_within_range_by_dataset_org(
             FROM source_rows src
             WHERE TRY_CAST(src.{value_col} AS BIGINT) IS NOT NULL
             AND TRIM(COALESCE(src.{lookup_dataset_col}, '')) != ''
-            AND TRIM(COALESCE(src."organisation", '')) != ''
-            {lookup_clause}
+            AND TRIM(COALESCE(src."organisation", '')) != ''{lookup_clause}
         )
 
         SELECT

--- a/digital_land/expectations/operations/csv.py
+++ b/digital_land/expectations/operations/csv.py
@@ -569,26 +569,10 @@ def check_field_is_within_range_by_dataset_org(
         if str(dataset).strip() and str(alias).strip()
     ]
 
-    # When dataset_aliases is empty, we still need a dummy CTE to avoid SQL errors in the main query.
     if dataset_alias_rows:
         values_clause = ",".join(dataset_alias_rows)
     else:
         values_clause = "(NULL, NULL)"
-
-    # Creates a CTE for alias mapping with rows e.g.:
-    # statistical-geography | ward
-    # statistical-geography | region
-    dataset_alias_cte = f"""
-    , dataset_aliases_map AS (
-        SELECT
-            CAST(dataset AS VARCHAR) AS dataset,
-            CAST(alias AS VARCHAR) AS alias
-        FROM (VALUES
-            {values_clause}
-        ) AS m(dataset, alias)
-        WHERE dataset IS NOT NULL
-    )
-    """
 
     query = f"""
     WITH
@@ -604,18 +588,26 @@ def check_field_is_within_range_by_dataset_org(
         AND TRY_CAST({max_col} AS BIGINT) IS NOT NULL
         AND TRIM(COALESCE({range_dataset_col}, '')) != ''
         AND TRIM(COALESCE("organisation", '')) != ''
-    )
+    ),
 
-    {dataset_alias_cte}
+    dataset_aliases_map AS (
+        SELECT
+            CAST(dataset AS VARCHAR) AS dataset,
+            CAST(alias AS VARCHAR) AS alias
+        FROM (VALUES
+            {values_clause}
+        ) AS m(dataset, alias)
+        WHERE dataset IS NOT NULL
+    ),
 
-    , source_rows AS (
+    source_rows AS (
         SELECT
             ROW_NUMBER() OVER () + 1 AS line_number,
             *
         FROM {_read_csv(file_path)}
-    )
+    ),
 
-    , lookup_rows AS (
+    lookup_rows AS (
         SELECT
             src.line_number,
             TRY_CAST(src.{value_col} AS BIGINT) AS value,

--- a/tests/integration/expectations/operations/test_csv.py
+++ b/tests/integration/expectations/operations/test_csv.py
@@ -473,6 +473,38 @@ def test_check_field_is_within_ranges_by_dataset_org_supports_custom_column_name
     assert details["invalid_rows"][0]["organisation"] == "org-a"
 
 
+def test_check_field_is_within_ranges_by_dataset_org_supports_prefix_dataset_map(
+    tmp_path,
+):
+    file_path = tmp_path / "lookup_exception.csv"
+    with open(file_path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["entity", "prefix", "organisation", "reference"])
+        writer.writerow(["150", "statistical-geography", "org-1", "ok-ref"])
+
+    external_file = tmp_path / "ranges_exception.csv"
+    with open(external_file, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["dataset", "organisation", "entity-minimum", "entity-maximum"])
+        writer.writerow(["ward", "org-1", "100", "200"])
+
+    conn = duckdb.connect()
+    passed, message, details = check_field_is_within_range_by_dataset_org(
+        conn,
+        file_path=file_path,
+        external_file=external_file,
+        min_field="entity-minimum",
+        max_field="entity-maximum",
+        field="entity",
+        lookup_dataset_field="prefix",
+        range_dataset_field="dataset",
+        prefix_datasets={"statistical-geography": ["ward", "lsoa"]},
+    )
+
+    assert passed is True
+    assert details["invalid_rows"] == []
+
+
 def test_check_field_is_within_ranges_filters_rows_with_lookup_rules(tmp_path):
     """Test filtering rows with lookup_rules during validation."""
     file_path = tmp_path / "lookup.csv"

--- a/tests/integration/expectations/operations/test_csv.py
+++ b/tests/integration/expectations/operations/test_csv.py
@@ -473,7 +473,7 @@ def test_check_field_is_within_ranges_by_dataset_org_supports_custom_column_name
     assert details["invalid_rows"][0]["organisation"] == "org-a"
 
 
-def test_check_field_is_within_ranges_by_dataset_org_supports_prefix_dataset_map(
+def test_check_field_is_within_ranges_by_dataset_org_supports_dataset_aliases_map(
     tmp_path,
 ):
     file_path = tmp_path / "lookup_exception.csv"

--- a/tests/integration/expectations/operations/test_csv.py
+++ b/tests/integration/expectations/operations/test_csv.py
@@ -498,7 +498,7 @@ def test_check_field_is_within_ranges_by_dataset_org_supports_prefix_dataset_map
         field="entity",
         lookup_dataset_field="prefix",
         range_dataset_field="dataset",
-        prefix_datasets={"statistical-geography": ["ward", "lsoa"]},
+        dataset_aliases={"statistical-geography": ["ward", "lsoa"]},
     )
 
     assert passed is True


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Optimization
- [x] Bug Fix
- [ ] Documentation Update

## Description

Added support for dataset alias mappings in range validation to handle cases where the lookup dataset field and range dataset field are not the same. This enables scenarios where a single lookup dataset value maps to multiple valid range dataset values. e.g in `lookup.csv`, prefix `statistical-geography `could be any of `ward` or `parish`

**Example Usage:**
```python
check_field_is_within_range_by_dataset_org(
    conn,
    file_path=file_path,
    external_file=external_file,
    field="entity",
    lookup_dataset_field="prefix",
    range_dataset_field="dataset",
    dataset_aliases={"statistical-geography": ["ward", "lsoa"]}
)
```

When `prefix="statistical-geography"`, the entity value will be validated against ranges for both `dataset="ward"` and `dataset="lsoa"`, rather than only `dataset="statistical-geography"`.


## Added/updated tests?

- [x] Yes
- [ ] No, and this is why:
- [ ] I need help with writing tests

Added integration test: `test_check_field_is_within_ranges_by_dataset_org_supports_prefix_dataset_map`
- Tests that lookup value "statistical-geography" correctly maps to range dataset values ["ward", "lsoa"]
- Validates entity value is checked against both range datasets when alias is configured

## [optional] Are there any post deployment tasks we need to perform?

None required. This is a backward-compatible enhancement. The `dataset_aliases` parameter is optional and defaults to `None`.

## [optional] Are there any dependencies on other PRs or Work?

None. This change is self-contained and does not depend on other work.

