### PR TITLE
Update GDAL installation to specify version in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ ifeq ($(UNAME),Darwin)
 endif
 	sudo add-apt-repository ppa:ubuntugis/ppa
 	sudo apt-get update
-	sudo apt-get install gdal-bin
+	GDAL_PKG=$$(apt-cache madison gdal-bin | awk '/3\.8\.4/ {print $$3; exit}') && \
+	sudo apt-get install -y gdal-bin=$$GDAL_PKG libgdal-dev=$$GDAL_PKG
 	gdalinfo --version
 endif
 ifndef SQLDIFF

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ ifeq ($(UNAME),Darwin)
 endif
 	sudo add-apt-repository ppa:ubuntugis/ppa
 	sudo apt-get update
-	GDAL_PKG=$$(apt-cache madison gdal-bin | awk '/3\.8\.4/ {print $$3; exit}') && \
-	sudo apt-get install -y gdal-bin=$$GDAL_PKG libgdal-dev=$$GDAL_PKG
+	GDAL_PKG=$$(apt-cache madison gdal-bin | awk '/3\.8\./ {print $$3; exit}') && \
+    sudo apt-get install -y gdal-bin=$$GDAL_PKG libgdal-dev=$$GDAL_PKG
 	gdalinfo --version
 endif
 ifndef SQLDIFF


### PR DESCRIPTION
This PR pins the GDAL dependency to version 3.8.4, which is known to consistently pass our test suite.

Currently, when GDAL is installed without a version, test results can vary between runs, leading to intermittent failures in the `convert` tests. For example:

* A run with GDAL 3.4.1 failed: [https://github.com/digital-land/digital-land-python/actions/runs/25371714310/job/74396623492#step:4:822](https://github.com/digital-land/digital-land-python/actions/runs/25371714310/job/74396623492#step:4:822)
* A run with GDAL 3.8.4 passed: [https://github.com/digital-land/digital-land-python/actions/runs/25167826454/job/73778618275#step:4:810](https://github.com/digital-land/digital-land-python/actions/runs/25167826454/job/73778618275#step:4:810)

Pinning the version removes this variability and ensures consistent, reliable test results across all runs.
