### PR TITLE
fix: remove split_curie from EntityReferencePhase

### DIFF
--- a/digital_land/phase/reference.py
+++ b/digital_land/phase/reference.py
@@ -41,23 +41,7 @@ class EntityReferencePhase(Phase):
 
     def process_row(self, row):
         reference = row.get("reference", "") or row.get(self.dataset, "")
-        reference_prefix, reference = split_curie(reference)
-
-        if self.issues and reference_prefix:
-            self.issues.log_issue(
-                "reference",
-                "reference value contains reference_prefix",
-                reference_prefix,
-                f"Original reference split into prefix '{reference_prefix}' and reference '{reference}'",
-            )
-
-        # crude fix for (hopefully) one-of issue with Newham Council
-        # if this type of problem becomes common, a more scalable
-        # solution will need to be sought.
-        if "UPRN" in reference_prefix:
-            reference_prefix = ""
-
-        prefix = row.get("prefix", "") or reference_prefix or self.prefix
+        prefix = row.get("prefix", "") or self.prefix
         return prefix, reference
 
     def process(self, stream):

--- a/tests/unit/phase/test_reference.py
+++ b/tests/unit/phase/test_reference.py
@@ -5,7 +5,6 @@ import pytest
 from digital_land.specification import Specification
 from digital_land.phase.reference import EntityReferencePhase, FactReferencePhase
 from digital_land.phase.reference import split_curie
-from digital_land.log import IssueLog
 
 
 def test_split_curie():
@@ -22,14 +21,10 @@ def test_entity_reference():
     assert ("foo", "Q1234") == phase.process_row(
         {"prefix": "foo", "reference": "Q1234"}
     )
-    assert ("wikidata", "Q1234") == phase.process_row({"reference": "wikidata:Q1234"})
     assert ("tree", "NSP22: Not A CURIE") == phase.process_row(
         {"reference": "NSP22: Not A CURIE"}
     )
     assert ("tree", "Not A CURIE:") == phase.process_row({"reference": "Not A CURIE:"})
-    assert ("foo", "Q1234") == phase.process_row(
-        {"prefix": "foo", "reference": "wikidata:Q1234"}
-    )
 
 
 def test_fact_reference():
@@ -104,13 +99,3 @@ def test_get_field_prefix_uses_field_name_for_missing_mapping():
 
     prefix = phase.get_field_prefix("reference")
     assert prefix == "reference"
-
-
-def test_entity_reference_with_prefix_issue():
-    issues = IssueLog()
-    phase = EntityReferencePhase(
-        dataset="developer-agreement", prefix="developer-agreement", issues=issues
-    )
-
-    assert ("DA", "20/21:CIL:1") == phase.process_row({"reference": "DA:20/21:CIL:1"})
-    assert issues.rows[0]["issue-type"] == "reference value contains reference_prefix"

--- a/tests/unit/phase/test_reference.py
+++ b/tests/unit/phase/test_reference.py
@@ -21,10 +21,14 @@ def test_entity_reference():
     assert ("foo", "Q1234") == phase.process_row(
         {"prefix": "foo", "reference": "Q1234"}
     )
+    assert ("wikidata", "Q1234") != phase.process_row({"reference": "wikidata:Q1234"})
     assert ("tree", "NSP22: Not A CURIE") == phase.process_row(
         {"reference": "NSP22: Not A CURIE"}
     )
     assert ("tree", "Not A CURIE:") == phase.process_row({"reference": "Not A CURIE:"})
+    assert ("foo", "Q1234") != phase.process_row(
+        {"prefix": "foo", "reference": "wikidata:Q1234"}
+    )
 
 
 def test_fact_reference():


### PR DESCRIPTION
## Description

Removing function `split_curie` as part of the `EntityReferencePhase` 

Removing issue logging for reference prefix

## Why

`split_curie` because it is no longer (nor ever has been) been required as data providers have never needed to provide references as a Curie.

Issue logging no longer required now we have identified the issues and that there is no need for this Curie handling code.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com/orgs/digital-land/projects/15/views/1pane=issue&itemId=113801168&issue=digital-land%7Cconfig%7C729)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

After discussing with Ben we are sure that there are in fact no data providers who are sending us curies and, given that the splitting is catching several colon-containing-references by mistake, we have deemed removing the function to be safe.

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
