### PR TITLE
Add promptUser parameter to check_and_assign_entities function to mak…

### DIFF
--- a/digital_land/commands.py
+++ b/digital_land/commands.py
@@ -1649,6 +1649,7 @@ def check_and_assign_entities(
     specification_dir,
     pipeline_dir,
     input_path=None,
+    prompt_user=True,
 ):
     # Assigns entities for the given resources in the given collection and run pipeline to get the transformed resource.
 
@@ -1733,7 +1734,7 @@ def check_and_assign_entities(
     issue_summary = get_issue_summary(endpoint_resource_info, issue_dir, new_entities)
     print(issue_summary)
 
-    if "No issues found" not in issue_summary:
+    if prompt_user and "No issues found" not in issue_summary:
         if not get_user_response(
             "Do you want to continue processing this resource? (yes/no): "
         ):

--- a/tests/integration/test_assign_entities.py
+++ b/tests/integration/test_assign_entities.py
@@ -356,6 +356,49 @@ def test_check_and_assign_entities(
     assert "invalid date  start-date    1" in out
 
 
+@patch(
+    "digital_land.commands.get_user_response",
+    side_effect=AssertionError("get_user_response should not be called"),
+)
+def test_check_and_assign_entities_prompt_flag_false(
+    mock_user_response,
+    capfd,
+    collection_dir,
+    pipeline_dir,
+    specification_dir,
+    organisation_path,
+    mock_resource,
+):
+    """
+    When prompt_user=False, `get_user_response` must not be called; function should complete
+    and produce the transformed file.
+    """
+    collection_name = "tree-preservation-order"
+    test_endpoint = "endpoint"
+
+    resource = os.path.basename(mock_resource)
+    input_path = Path("var/cache/assign_entities/transformed") / f"{resource}.csv"
+
+    # Run with prompt_user explicitly False
+    check_and_assign_entities(
+        resource_file_paths=[mock_resource],
+        endpoints=[test_endpoint],
+        collection_name=collection_name,
+        dataset=collection_name,
+        organisation=["government-organisation:D1342"],
+        collection_dir=collection_dir,
+        organisation_path=organisation_path,
+        specification_dir=specification_dir,
+        pipeline_dir=pipeline_dir,
+        input_path=input_path,
+        prompt_user=False,
+    )
+
+    assert (
+        input_path.exists()
+    ), "Expected transformed file not found when prompt_user=False."
+
+
 def test_command_assign_entities_reference_with_comma(
     collection_dir,
     pipeline_dir,


### PR DESCRIPTION
…e the user prompt optional

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

check_and_assign_entities has a prompt within it to prompt the user if they want to proceed with processing the resource. I added a flag to disable the prompt so that it becomes optional. This is part of a larger effort to make batch assign automated.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Ticket Link
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
