### PR TITLE
refactor: rearrange count_deleted_entities to run once per dataset

### DIFF
--- a/digital_land/expectations/checkpoints/dataset.py
+++ b/digital_land/expectations/checkpoints/dataset.py
@@ -11,6 +11,7 @@ from ..operations.dataset import (
     count_lpa_boundary,
     count_deleted_entities,
     duplicate_geometry_check,
+    fetch_active_resources_for_dataset,
 )
 
 
@@ -134,15 +135,24 @@ class DatasetCheckpoint(BaseCheckpoint):
 
         return passed, msg, details
 
-    def run(self):
+    def run(self, prefetch_resources=False):
         """
         run the set of expectations that have been loaded into the checkpoint
-        results will be stoed in the log and can be saved used .save
+        results will be stored in the log and can be saved used .save
         """
         # TODO implement faillure on critical errors, this is also the zombie code below
         # self.failed_expectation_with_error_severity = 0
 
+        resources_cache = (
+            fetch_active_resources_for_dataset(self.dataset)
+            if prefetch_resources
+            else None
+        )
+
         for expectation in self.expectations:
+            if resources_cache is not None:
+                expectation["parameters"]["resources_cache"] = resources_cache
+
             passed, message, details = self.run_expectation(expectation)
             self.log.add(
                 {

--- a/digital_land/expectations/commands.py
+++ b/digital_land/expectations/commands.py
@@ -25,7 +25,10 @@ def run_dataset_checkpoint(
     rules = config.get_expectation_rules(dataset)
     checkpoint = DatasetCheckpoint(dataset, file_path, organisations)
     checkpoint.load(rules)
-    checkpoint.run()
+    prefetch_resources = any(
+        rule["operation"] == "count_deleted_entities" for rule in rules
+    )
+    checkpoint.run(prefetch_resources=prefetch_resources)
     checkpoint.save(output_dir)
     # TODO add failure on critical error back in
     if act_on_critical_error:

--- a/digital_land/expectations/operations/dataset.py
+++ b/digital_land/expectations/operations/dataset.py
@@ -127,41 +127,78 @@ def count_lpa_boundary(
     return result, message, details
 
 
-def count_deleted_entities(
-    conn,
-    expected: int,
-    organisation_entity: int = None,
-):
-    # get database name to identify dataset
-    db_path = conn.execute("PRAGMA database_list").fetchall()[0][2]
-    db_name = os.path.splitext(os.path.basename(db_path))[0]
-
-    # get dataset specific active resource list
+def fetch_active_resources_for_dataset(dataset_name):
     params = urllib.parse.urlencode(
         {
-            "sql": f"""select * from reporting_historic_endpoints rhe join organisation o on rhe.organisation=o.organisation
-                        where pipeline == '{db_name}' and o.entity='{organisation_entity}' and resource_end_date == "" group by endpoint""",
+            "sql": f"""select o.entity as organisation_entity, rhe.resource
+                        from reporting_historic_endpoints rhe
+                        join organisation o on rhe.organisation=o.organisation
+                        where pipeline == '{dataset_name}' and resource_end_date == ""
+                        group by o.entity, rhe.endpoint""",
             "_size": "max",
         }
     )
     base_url = f"https://datasette.planning.data.gov.uk/digital-land.csv?{params}"
 
-    # Can have an issue getting data from datasette. If this occurs then wait a minute and retry
-    max_retries = 60  # Retry for an hour
+    max_retries = 60
     for attempt in range(max_retries):
         try:
-            get_resource = pd.read_csv(base_url)
-            break
+            df = pd.read_csv(base_url)
+            cache = {}
+            for _, row in df.iterrows():
+                cache.setdefault(row["organisation_entity"], []).append(row["resource"])
+            return cache
         except urllib.error.HTTPError as e:
             logging.warning(
-                f"HTTP error fetching datasette for organisation {organisation_entity}, "
+                f"HTTP error fetching datasette for dataset {dataset_name}, "
                 f"attempt {attempt + 1}/{max_retries}: {e}. Retrying in 60s..."
             )
             time.sleep(60)
-    else:
-        raise Exception("Failed to fetch datasette after multiple attempts")
+    raise Exception(
+        f"Failed to fetch datasette for dataset {dataset_name} after multiple attempts"
+    )
 
-    resource_list = get_resource["resource"].to_list()
+
+def count_deleted_entities(
+    conn,
+    expected: int,
+    organisation_entity: int = None,
+    resources_cache: dict = None,
+):
+    # get database name to identify dataset
+    db_path = conn.execute("PRAGMA database_list").fetchall()[0][2]
+    db_name = os.path.splitext(os.path.basename(db_path))[0]
+
+    # check if entity data has been fetched from datasette and stored in the cache
+    if resources_cache is not None:
+        resource_list = resources_cache.get(organisation_entity, [])
+    else:
+        # get dataset specific active resource list if nothing is found it
+        params = urllib.parse.urlencode(
+            {
+                "sql": f"""select * from reporting_historic_endpoints rhe join organisation o on rhe.organisation=o.organisation
+                            where pipeline == '{db_name}' and o.entity='{organisation_entity}' and resource_end_date == "" group by endpoint""",
+                "_size": "max",
+            }
+        )
+        base_url = f"https://datasette.planning.data.gov.uk/digital-land.csv?{params}"
+
+        # Can have an issue getting data from datasette. If this occurs then wait a minute and retry
+        max_retries = 60  # Retry for an hour
+        for attempt in range(max_retries):
+            try:
+                get_resource = pd.read_csv(base_url)
+                break
+            except urllib.error.HTTPError as e:
+                logging.warning(
+                    f"HTTP error fetching datasette for organisation {organisation_entity}, "
+                    f"attempt {attempt + 1}/{max_retries}: {e}. Retrying in 60s..."
+                )
+                time.sleep(60)
+        else:
+            raise Exception("Failed to fetch datasette after multiple attempts")
+
+        resource_list = get_resource["resource"].to_list()
 
     # use resource list to get current entities
     query = f"""select f.entity

--- a/tests/integration/expectations/checkpoints/test_dataset.py
+++ b/tests/integration/expectations/checkpoints/test_dataset.py
@@ -194,6 +194,49 @@ class TestDatasetCheckpoint:
         assert log.entries[0]["passed"] is True
         assert log.entries[0]["message"] == "this operation is a test and always passes"
 
+    def test_run_with_prefetch_fetches_once_and_injects_cache(
+        self, sqlite3_with_entity_tables_path, mocker, test_organisations
+    ):
+        mock_fetch = mocker.patch(
+            "digital_land.expectations.checkpoints.dataset.fetch_active_resources_for_dataset",
+            return_value={101: ["resource_a"]},
+        )
+        mock_function = mocker.Mock(return_value=(True, "passed", {}))
+        mock_function.__name__ = "count_deleted_entities"
+        mocker.patch(
+            "digital_land.expectations.checkpoints.dataset.DatasetCheckpoint.operation_factory",
+            return_value=mock_function,
+        )
+
+        checkpoint = DatasetCheckpoint(
+            dataset="test-dataset",
+            file_path=sqlite3_with_entity_tables_path,
+            organisations=test_organisations,
+        )
+        rules = [
+            {
+                "datasets": "test-dataset",
+                "organisations": "local-authority:test;local-authority:test_2",
+                "operation": "count_deleted_entities",
+                "parameters": '{"organisation_entity": {{ organisation.entity }}, "expected": 0}',
+                "name": "test expectation for {{ organisation.name }}",
+                "description": "",
+                "severity": "notice",
+                "responsibility": "internal",
+            }
+        ]
+        checkpoint.load(rules)
+        checkpoint.run(prefetch_resources=True)
+
+        # datasette fetched exactly once despite two organisations
+        mock_fetch.assert_called_once_with("test-dataset")
+
+        # cache was injected into every operation call
+        for call in mock_function.call_args_list:
+            assert call.kwargs["resources_cache"] == {101: ["resource_a"]}
+
+        assert len(checkpoint.log.entries) == 2
+
     def test_save_to_parquet(self, tmp_path, test_organisations):
         """
         assuming run is successful then the log exists and can be saved

--- a/tests/integration/expectations/operations/test_dataset.py
+++ b/tests/integration/expectations/operations/test_dataset.py
@@ -8,6 +8,7 @@ from digital_land.expectations.operations.dataset import (
     count_lpa_boundary,
     count_deleted_entities,
     duplicate_geometry_check,
+    fetch_active_resources_for_dataset,
 )
 
 
@@ -117,6 +118,20 @@ def test_count_lpa_boundary_passes(
         assert key in details, f"{key} missing from details"
 
 
+def test_fetch_active_resources_for_dataset(mocker):
+    mock_df = pd.DataFrame(
+        {
+            "organisation_entity": [101, 101, 102],
+            "resource": ["resource_a", "resource_b", "resource_c"],
+        }
+    )
+    mocker.patch("pandas.read_csv", return_value=mock_df)
+
+    result = fetch_active_resources_for_dataset("test-dataset")
+
+    assert result == {101: ["resource_a", "resource_b"], 102: ["resource_c"]}
+
+
 def test_count_deleted_entities(dataset_path, mocker):
     # define constant parameters
     organisation_entity = 109
@@ -176,6 +191,56 @@ def test_count_deleted_entities(dataset_path, mocker):
     detail_keys = ["actual", "expected", "entities"]
     for key in detail_keys:
         assert key in details, f"{key} missing from details"
+    assert "1002" in details["entities"]
+
+
+def test_count_deleted_entities_uses_cache_instead_of_http(dataset_path, mocker):
+    organisation_entity = 109
+    expected = 0
+
+    test_entity_data = pd.DataFrame.from_dict(
+        {
+            "entity": ["1001", "1002"],
+            "name": ["test1", "test2"],
+            "organisation_entity": [109, 109],
+            "reference": ["ref1", "ref2"],
+        }
+    )
+    test_fact_resource_data = pd.DataFrame.from_dict(
+        {
+            "fact": ["036d2b946bd41", "16bf38800aafd"],
+            "resource": ["2f7d900dd48fd02", "2f7d900dd48fd02"],
+            "entry_number": ["1", "1"],
+        }
+    )
+    test_fact_data = pd.DataFrame.from_dict(
+        {
+            "fact": ["036d2b946bd41", "16bf38800aafd"],
+            "entity": ["1001", "1001"],
+            "field": ["name", "reference"],
+            "value": ["abc", "ref1"],
+        }
+    )
+
+    mock_read_csv = mocker.patch("pandas.read_csv")
+    resources_cache = {109: ["2f7d900dd48fd02"]}
+
+    with spatialite.connect(dataset_path) as conn:
+        test_entity_data.to_sql("entity", conn, if_exists="replace", index=False)
+        test_fact_resource_data.to_sql(
+            "fact_resource", conn, if_exists="replace", index=False
+        )
+        test_fact_data.to_sql("fact", conn, if_exists="replace", index=False)
+
+        passed, _, details = count_deleted_entities(
+            conn,
+            expected=expected,
+            organisation_entity=organisation_entity,
+            resources_cache=resources_cache,
+        )
+
+    mock_read_csv.assert_not_called()
+    assert not passed
     assert "1002" in details["entities"]
 
 


### PR DESCRIPTION
## Description

As part of the `assemble-and-bake pipeline` step we `Run dataset expectations...` this includes a function called `count_deleted_entities`. `count_deleted_entities` make one HTTP request to datasette per organisation (for brownfield-site that is 342 orgs as defined in `collection-task/pipeline/expect.csv`), different pipelines have different numbers of orgs but in some worst-case pipelines we are talking hundreds of HTTP requests to datasette per dataset.

This PR refactors that code so that it makes the HTTP request once per dataset, getting data for multiple organisations at once, this should reduce the load on datasette throughout the night.

## Why
Datasette is getting overwhelmed between the hours of 1am and 3am each night, because of all of these HTTP requests. I believe refactoring these requests to consolidate them will reduce the load on datasettee each night and enable the pipelines to run faster.

## Tests
So all the automated tests are passing as you can see.
I have run the pipeline locally on `ownership-status` and `brownfield-site` everything seemed to run fine, no errors or failures.

When ran locally - brownfield-site checked the 342 orgs and produced what looks like 312 passing, 30 genuine data quality failures (organisations with missing entities), which I guess seems about right.


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com/orgs/digital-land/projects/15/views/1?pane=issue&itemId=161656529&issue=digital-land%7Cconfig%7C2286)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
