### PR TITLE
fix: only pass resources_cache to operations that explicitly accept it

### DIFF
--- a/digital_land/expectations/checkpoints/dataset.py
+++ b/digital_land/expectations/checkpoints/dataset.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 import spatialite
 from pathlib import Path
@@ -151,7 +152,10 @@ class DatasetCheckpoint(BaseCheckpoint):
 
         for expectation in self.expectations:
             if resources_cache is not None:
-                expectation["parameters"]["resources_cache"] = resources_cache
+                operation = expectation["operation"]
+                # only pass resources_cache to operations that explicitly accept it
+                if "resources_cache" in inspect.signature(operation).parameters:
+                    expectation["parameters"]["resources_cache"] = resources_cache
 
             passed, message, details = self.run_expectation(expectation)
             self.log.add(

--- a/tests/integration/expectations/checkpoints/test_dataset.py
+++ b/tests/integration/expectations/checkpoints/test_dataset.py
@@ -3,6 +3,8 @@ import spatialite
 import logging
 import pandas as pd
 from digital_land.expectations.checkpoints.dataset import DatasetCheckpoint
+from digital_land.expectations.operations.dataset import count_deleted_entities
+
 from digital_land.organisation import Organisation
 
 
@@ -201,7 +203,9 @@ class TestDatasetCheckpoint:
             "digital_land.expectations.checkpoints.dataset.fetch_active_resources_for_dataset",
             return_value={101: ["resource_a"]},
         )
-        mock_function = mocker.Mock(return_value=(True, "passed", {}))
+        mock_function = mocker.create_autospec(
+            count_deleted_entities, return_value=(True, "passed", {})
+        )
         mock_function.__name__ = "count_deleted_entities"
         mocker.patch(
             "digital_land.expectations.checkpoints.dataset.DatasetCheckpoint.operation_factory",
@@ -236,6 +240,49 @@ class TestDatasetCheckpoint:
             assert call.kwargs["resources_cache"] == {101: ["resource_a"]}
 
         assert len(checkpoint.log.entries) == 2
+
+    def test_run_with_prefetch_does_not_inject_cache_into_incompatible_operations(
+        self, sqlite3_with_entity_tables_path, mocker, test_organisations
+    ):
+        """
+        Regression test: resources_cache should only be passed to operations that
+        explicitly accept it in their signature. If the inspect.signature check is
+        removed, this will fail with:
+        TypeError: operation_without_cache() got an unexpected keyword argument 'resources_cache'
+        """
+        mocker.patch(
+            "digital_land.expectations.checkpoints.dataset.fetch_active_resources_for_dataset",
+            return_value={101: ["resource_a"]},
+        )
+
+        def operation_without_cache(conn, expected: int):
+            return True, "passed", {}
+
+        mocker.patch.object(
+            DatasetCheckpoint,
+            "operation_factory",
+            return_value=operation_without_cache,
+        )
+
+        checkpoint = DatasetCheckpoint(
+            dataset="test-dataset",
+            file_path=sqlite3_with_entity_tables_path,
+            organisations=test_organisations,
+        )
+        rules = [
+            {
+                "datasets": "test-dataset",
+                "organisations": "",
+                "operation": "operation_without_cache",
+                "parameters": '{"expected": 0}',
+                "name": "test expectation",
+                "description": "",
+                "severity": "notice",
+                "responsibility": "internal",
+            }
+        ]
+        checkpoint.load(rules)
+        checkpoint.run(prefetch_resources=True)
 
     def test_save_to_parquet(self, tmp_path, test_organisations):
         """


### PR DESCRIPTION
## Description

Changing the expectations loop to only pass resources_cache to operations that explicitly accept it.

## Why 
Because otherwise the pipelines which run 'duplicate_geometry_check' or  `count_lpa_boundary` will error during checks, I discovered this while testing locally.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Ticket Link
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
