### PR TITLE
Implement the NULL resource_end_date bug fix

### DIFF
--- a/digital_land/expectations/operations/dataset.py
+++ b/digital_land/expectations/operations/dataset.py
@@ -126,6 +126,7 @@ def count_lpa_boundary(
 
     return result, message, details
 
+
 # Previously named count_deleted_entities() function
 def fetch_active_resources_for_dataset(dataset_name):
     params = urllib.parse.urlencode(

--- a/digital_land/expectations/operations/dataset.py
+++ b/digital_land/expectations/operations/dataset.py
@@ -133,7 +133,7 @@ def fetch_active_resources_for_dataset(dataset_name):
             "sql": f"""select o.entity as organisation_entity, rhe.resource
                         from reporting_historic_endpoints rhe
                         join organisation o on rhe.organisation=o.organisation
-                        where pipeline == '{dataset_name}' and resource_end_date == ""
+                        where pipeline == '{dataset_name}' and (resource_end_date == "" or resource_end_date is null)
                         group by o.entity, rhe.endpoint""",
             "_size": "max",
         }

--- a/digital_land/expectations/operations/dataset.py
+++ b/digital_land/expectations/operations/dataset.py
@@ -126,7 +126,7 @@ def count_lpa_boundary(
 
     return result, message, details
 
-
+# Previously named count_deleted_entities() function
 def fetch_active_resources_for_dataset(dataset_name):
     params = urllib.parse.urlencode(
         {

--- a/tests/integration/expectations/operations/test_dataset.py
+++ b/tests/integration/expectations/operations/test_dataset.py
@@ -133,11 +133,12 @@ def test_fetch_active_resources_for_dataset(mocker):
 
 
 def test_count_deleted_entities(dataset_path, mocker):
-    # define constant parameters
+    """Entity with no facts in the active resource is reported as deleted."""
     organisation_entity = 109
     expected = 0
 
     # load data into sqlite for entity, fact_resource and fact table
+    # entity 1001 has facts in the active resource; entity 1002 does not
     test_entity_data = pd.DataFrame.from_dict(
         {
             "entity": ["1001", "1002"],
@@ -183,15 +184,126 @@ def test_count_deleted_entities(dataset_path, mocker):
             organisation_entity=organisation_entity,
         )
 
-    assert (
-        not passed
-    ), f"test failed : expected {details['expected']} but got {details['actual']} entities"
-    assert message, "test requires a message"
-
-    detail_keys = ["actual", "expected", "entities"]
-    for key in detail_keys:
+    assert not passed, "expected to fail (1 deleted) but passed"
+    assert message
+    for key in ["actual", "expected", "entities"]:
         assert key in details, f"{key} missing from details"
+    assert details["actual"] == 1
     assert "1002" in details["entities"]
+
+
+def test_count_deleted_entities_none_deleted(dataset_path, mocker):
+    """All entities have facts in the active resource — 0 deleted, check passes."""
+    organisation_entity = 109
+
+    test_entity_data = pd.DataFrame.from_dict(
+        {
+            "entity": ["1001", "1002"],
+            "name": ["test1", "test2"],
+            "organisation_entity": [109, 109],
+            "reference": ["ref1", "ref2"],
+        }
+    )
+
+    test_fact_resource_data = pd.DataFrame.from_dict(
+        {
+            "fact": ["fact-a", "fact-b"],
+            "resource": ["res-active", "res-active"],
+            "entry_number": ["1", "2"],
+        }
+    )
+
+    test_fact_data = pd.DataFrame.from_dict(
+        {
+            "fact": ["fact-a", "fact-b"],
+            "entity": ["1001", "1002"],
+            "field": ["name", "name"],
+            "value": ["test1", "test2"],
+        }
+    )
+
+    mock_df = pd.DataFrame({"resource": ["res-active"]})
+    mocker.patch("pandas.read_csv", return_value=mock_df)
+
+    with spatialite.connect(dataset_path) as conn:
+        test_entity_data.to_sql("entity", conn, if_exists="replace", index=False)
+        test_fact_resource_data.to_sql(
+            "fact_resource", conn, if_exists="replace", index=False
+        )
+        test_fact_data.to_sql("fact", conn, if_exists="replace", index=False)
+
+        passed, message, details = count_deleted_entities(
+            conn,
+            expected=0,
+            organisation_entity=organisation_entity,
+        )
+
+    assert passed, f"expected 0 deleted but got {details['actual']}"
+    assert details["actual"] == 0
+    assert details["entities"] == []
+
+
+def test_count_deleted_entities_org_isolation(dataset_path, mocker):
+    """
+    Facts for a second organisation's entity in the same resource must not
+    cause that entity to be counted as active for the queried organisation.
+
+    Setup: org 109 has entities 1001 (active) and 1002 (deleted). Org 200
+    has entity 2001 with a fact in the same resource. Only 1002 should be
+    reported as deleted for org 109; entity 2001 must be excluded entirely.
+    """
+    organisation_entity = 109
+
+    test_entity_data = pd.DataFrame.from_dict(
+        {
+            "entity": ["1001", "1002", "2001"],
+            "name": ["org109 tree A", "org109 tree B", "org200 tree"],
+            "organisation_entity": [109, 109, 200],
+            "reference": ["T1", "T2", "T3"],
+        }
+    )
+
+    test_fact_resource_data = pd.DataFrame.from_dict(
+        {
+            "fact": ["fact-a", "fact-x"],
+            "resource": ["res-active", "res-active"],
+            "entry_number": ["1", "2"],
+        }
+    )
+
+    # fact-a belongs to org 109's entity 1001; fact-x belongs to org 200's entity 2001
+    test_fact_data = pd.DataFrame.from_dict(
+        {
+            "fact": ["fact-a", "fact-x"],
+            "entity": ["1001", "2001"],
+            "field": ["name", "name"],
+            "value": ["org109 tree A", "org200 tree"],
+        }
+    )
+
+    mock_df = pd.DataFrame({"resource": ["res-active"]})
+    mocker.patch("pandas.read_csv", return_value=mock_df)
+
+    with spatialite.connect(dataset_path) as conn:
+        test_entity_data.to_sql("entity", conn, if_exists="replace", index=False)
+        test_fact_resource_data.to_sql(
+            "fact_resource", conn, if_exists="replace", index=False
+        )
+        test_fact_data.to_sql("fact", conn, if_exists="replace", index=False)
+
+        passed, message, details = count_deleted_entities(
+            conn,
+            expected=1,
+            organisation_entity=organisation_entity,
+        )
+
+    assert passed, (
+        f"expected exactly 1 deleted entity (1002) but got {details['actual']}: "
+        f"{details['entities']}"
+    )
+    assert details["actual"] == 1
+    assert "1002" in details["entities"]
+    assert "2001" not in details["entities"]
 
 
 def test_count_deleted_entities_uses_cache_instead_of_http(dataset_path, mocker):


### PR DESCRIPTION
This PR was previously #528 and #531. These PRs were reverted due to believing they were causing hour long delays in Airflow every night. Subsequent investigations by @tombrooks248 and @salabi (https://github.com/orgs/digital-land/projects/15?pane=issue&itemId=161656529&issue=digital-land%7Cconfig%7C2286) found that the delays were caused by the way the code was retrieving data from Datasette.

I am now re-testing if their edits to the code will allow my NULL bug fix to be implemented without any additional delays.
We're still keen to fix the NULL date, given it is causing 1000s of entities to be recorded as deleted erroneously.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR addresses a bug found within the deleted entities expectation.

1. resource_end_date filter
Active resources are fetched from reporting_historic_endpoints using a filter on resource_end_date. Some active resources store NULL in this field rather than an empty string, so they were being excluded. The filter was updated to (resource_end_date = '' OR resource_end_date IS NULL).


## Related Tickets & Documents
- Ticket Link: https://github.com/orgs/digital-land/projects/15/views/1?pane=issue&itemId=161656529&issue=digital-land%7Cconfig%7C2286

## QA Instructions, Screenshots, Recordings
Run the integration tests for count_deleted_entities:

`pytest tests/integration/expectations/operations/test_dataset.py -v -k "deleted"`

This covers:
- The baseline case (one entity with no active facts is reported deleted)
- All entities active — check passes with 0 deleted
- Entities with empty reference strings — regression test for the GROUP BY collapse bug
- Organisation isolation — facts from a second org's resource don't affect the queried org's count

## Added/updated tests?
- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests