### PR TITLE
feat: adding logging to our expectations calls

### DIFF
--- a/digital_land/expectations/checkpoints/dataset.py
+++ b/digital_land/expectations/checkpoints/dataset.py
@@ -1,5 +1,6 @@
 import inspect
 import json
+import logging
 import spatialite
 from pathlib import Path
 from jinja2 import Template
@@ -144,13 +145,17 @@ class DatasetCheckpoint(BaseCheckpoint):
         # TODO implement faillure on critical errors, this is also the zombie code below
         # self.failed_expectation_with_error_severity = 0
 
-        resources_cache = (
-            fetch_active_resources_for_dataset(self.dataset)
-            if prefetch_resources
-            else None
+        logger = logging.getLogger(__name__)
+        logger.info(
+            f"[expectations] Starting run for dataset '{self.dataset}' with {len(self.expectations)} expectations"
         )
 
-        for expectation in self.expectations:
+        resources_cache = None
+        if prefetch_resources:
+            resources_cache = fetch_active_resources_for_dataset(self.dataset)
+            logger.info("[expectations] Prefetched resources cache")
+
+        for i, expectation in enumerate(self.expectations):
             if resources_cache is not None:
                 operation = expectation["operation"]
                 # only pass resources_cache to operations that explicitly accept it
@@ -158,6 +163,15 @@ class DatasetCheckpoint(BaseCheckpoint):
                     expectation["parameters"]["resources_cache"] = resources_cache
 
             passed, message, details = self.run_expectation(expectation)
+
+            # generating logging statements for each expectation per orgaisation
+            org = expectation.get("organisation", {})
+            org_name = org.get("organisation", "") if org else ""
+            label = f"{expectation['operation'].__name__}({org_name})"
+            logger.info(
+                f"[expectations] {i+1}/{len(self.expectations)} {label} — {'PASSED' if passed else 'FAILED'}"
+            )
+
             self.log.add(
                 {
                     "organisation": (

--- a/digital_land/expectations/operations/dataset.py
+++ b/digital_land/expectations/operations/dataset.py
@@ -145,6 +145,9 @@ def fetch_active_resources_for_dataset(dataset_name):
     for attempt in range(max_retries):
         try:
             df = pd.read_csv(base_url)
+            logging.info(
+                f"[expectations] Fetched {len(df)} active resources for '{dataset_name}' from datasette"
+            )
             cache = {}
             for _, row in df.iterrows():
                 cache.setdefault(row["organisation_entity"], []).append(row["resource"])


### PR DESCRIPTION
## Description

Adding logging to the expectations code including after the each of the 3 expectations functions runs on each organisation.

## Why
Because this is taking 2-3 hours on some of our larger datasets e.g. tree-preservation-order and I want to understand which bit of the code is taking so long to run, in the hope this might point us towards a fix to making it all run faster. 

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com/orgs/digital-land/projects/15/views/1?pane=issue&itemId=179396849&issue=digital-land%7Cdigital-land-python%7C526)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [x] No, and this is why: Just adding logging, no tests required.
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
