### PR TITLE
fix: make expectations logging use warnings not info

### DIFF
--- a/digital_land/expectations/checkpoints/dataset.py
+++ b/digital_land/expectations/checkpoints/dataset.py
@@ -146,14 +146,14 @@ class DatasetCheckpoint(BaseCheckpoint):
         # self.failed_expectation_with_error_severity = 0
 
         logger = logging.getLogger(__name__)
-        logger.info(
+        logger.warning(
             f"[expectations] Starting run for dataset '{self.dataset}' with {len(self.expectations)} expectations"
         )
 
         resources_cache = None
         if prefetch_resources:
             resources_cache = fetch_active_resources_for_dataset(self.dataset)
-            logger.info("[expectations] Prefetched resources cache")
+            logger.warning("[expectations] Prefetched resources cache")
 
         for i, expectation in enumerate(self.expectations):
             if resources_cache is not None:
@@ -168,7 +168,7 @@ class DatasetCheckpoint(BaseCheckpoint):
             org = expectation.get("organisation", {})
             org_name = org.get("organisation", "") if org else ""
             label = f"{expectation['operation'].__name__}({org_name})"
-            logger.info(
+            logger.warning(
                 f"[expectations] {i+1}/{len(self.expectations)} {label} — {'PASSED' if passed else 'FAILED'}"
             )
 

--- a/digital_land/expectations/operations/dataset.py
+++ b/digital_land/expectations/operations/dataset.py
@@ -145,7 +145,7 @@ def fetch_active_resources_for_dataset(dataset_name):
     for attempt in range(max_retries):
         try:
             df = pd.read_csv(base_url)
-            logging.info(
+            logging.warning(
                 f"[expectations] Fetched {len(df)} active resources for '{dataset_name}' from datasette"
             )
             cache = {}


### PR DESCRIPTION
## Description

Change the logging messages to be `logger.warning` not `logger.info`

## Why

The default logger only shows logging messages set to logger.warning or above. 

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com/orgs/digital-land/projects/15?pane=issue&itemId=161656529&issue=digital-land%7Cconfig%7C2286)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
