### PR TITLE
feat: only run expectations if today matches scheduled day

### DIFF
--- a/digital_land/expectations/checkpoints/dataset.py
+++ b/digital_land/expectations/checkpoints/dataset.py
@@ -2,6 +2,7 @@ import inspect
 import json
 import logging
 import spatialite
+from datetime import datetime
 from pathlib import Path
 from jinja2 import Template
 
@@ -114,7 +115,12 @@ class DatasetCheckpoint(BaseCheckpoint):
         expectations need parsing
         """
         self.expectations = []
+        today = datetime.now().strftime("%A").lower()
         for rule in rules:
+            schedule = rule.get("schedule", "")
+            # skip rule if today does not match scheduled day of the week.
+            if schedule and schedule.lower() != today:
+                continue
             if rule["organisations"]:
                 rule_orgs = self.get_rule_orgs(rule)
 

--- a/tests/integration/expectations/checkpoints/test_dataset.py
+++ b/tests/integration/expectations/checkpoints/test_dataset.py
@@ -144,6 +144,61 @@ class TestDatasetCheckpoint:
             for expectation in checkpoint.expectations:
                 assert expectation.get(key) is not None
 
+    def test_load_skips_rule_not_scheduled_today(self, test_organisations, mocker):
+        """test loading skips rules not schedule for today, shoulld be moved to unit"""
+        from unittest.mock import patch
+
+        rules = [
+            {
+                "datasets": "test",
+                "organisations": "",
+                "operation": "test",
+                "parameters": '{"test":"test"}',
+                "name": "a saturday only rule",
+                "severity": "notice",
+                "responsibility": "internal",
+                "schedule": "saturday",
+            }
+        ]
+        mocker.patch(
+            "digital_land.expectations.checkpoints.dataset.DatasetCheckpoint.operation_factory",
+            return_value=mocker.Mock(return_value=True),
+        )
+        # force "today" to be a non-saturday
+        with patch("digital_land.expectations.checkpoints.dataset.datetime") as mock_dt:
+            mock_dt.now.return_value.strftime.return_value = "wednesday"
+            checkpoint = DatasetCheckpoint("dataset", "test-path", test_organisations)
+            checkpoint.load(rules)
+
+        assert len(checkpoint.expectations) == 0
+
+    def test_load_includes_rule_scheduled_for_today(self, test_organisations, mocker):
+        """test loading includes rules scheduled for today, shoulld be moved to unit"""
+        from unittest.mock import patch
+
+        rules = [
+            {
+                "datasets": "test",
+                "organisations": "",
+                "operation": "test",
+                "parameters": '{"test":"test"}',
+                "name": "a saturday only rule",
+                "severity": "notice",
+                "responsibility": "internal",
+                "schedule": "saturday",
+            }
+        ]
+        mocker.patch(
+            "digital_land.expectations.checkpoints.dataset.DatasetCheckpoint.operation_factory",
+            return_value=mocker.Mock(return_value=True),
+        )
+        with patch("digital_land.expectations.checkpoints.dataset.datetime") as mock_dt:
+            mock_dt.now.return_value.strftime.return_value = "saturday"
+            checkpoint = DatasetCheckpoint("dataset", "test-path", test_organisations)
+            checkpoint.load(rules)
+
+        assert len(checkpoint.expectations) == 1
+
     def test_run_success(
         self, tmp_path, sqlite3_with_entity_tables_path, mocker, test_organisations
     ):


### PR DESCRIPTION
## Description

Configure expectations rule generation so that it can skip a rule if that rule has a schedule set and today is not the day of the week set in the schedule.

## Why
Tree and Tree Preservation Order when they run duplicate_geometry_check take a long time slowing down the pipelines this change will enable us to only run those checks on saturdays when it doesnt matter if the pipelines take a bit longer.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com/orgs/digital-land/projects/15/views/1?pane=issue&itemId=189429676&issue=digital-land%7Cdigital-land-python%7C552)
- [Linked PR](https://github.com/digital-land/config/pull/2612) making relevant changes to config repo
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

I have also run a full run through of ancient-woodland locally and it seems to run as expected.

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
