### PR TITLE
fix fact selection priority order

### DIFF
--- a/digital_land/package/dataset.py
+++ b/digital_land/package/dataset.py
@@ -160,9 +160,11 @@ class DatasetPackage(SqlitePackage):
         self.connect()
         self.create_cursor()
         self.execute(
-            "select entity, field, value, priority from fact"
-            "  where value != '' or field == 'end-date'"
-            "  order by entity, field, priority, entry_date"
+            "select fact.entity, fact.field, fact.value, fact.priority from fact"
+            "  left join (select fact, max(start_date) start_date from fact_resource group by fact) fact_resource"
+            "  on fact.fact = fact_resource.fact"
+            "  where fact.value != '' or fact.field == 'end-date'"
+            "  order by fact.entity, fact.field, fact.priority, fact.entry_date, fact_resource.start_date"
         )
         results = self.cursor.fetchall()
 

--- a/tests/integration/package/test_dataset.py
+++ b/tests/integration/package/test_dataset.py
@@ -77,6 +77,110 @@ def blank_patch_csv(tmp_path):
     return patch_path
 
 
+def test_load_entities_uses_resource_start_date_as_tiebreaker(tmp_path):
+    class OrganisationStub:
+        organisation = {}
+
+    specification_dir = Path(__file__).parents[2] / "data" / "state" / "specification"
+    package = DatasetPackage(
+        "conservation-area",
+        organisation=OrganisationStub(),
+        path=os.path.join(tmp_path, "test.sqlite3"),
+        specification_dir=specification_dir,
+    )
+    package.create_database()
+    package.disconnect()
+
+    with sqlite3.connect(package.path) as connection:
+        connection.executemany(
+            """
+            INSERT INTO fact (
+                fact, entity, field, value, priority, entry_date, start_date, end_date, reference_entity
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    "fact-reference",
+                    "44006677",
+                    "reference",
+                    "ca-1",
+                    "2",
+                    "2024-01-01",
+                    "",
+                    "",
+                    "",
+                ),
+                (
+                    "fact-name-old-resource",
+                    "44006677",
+                    "name",
+                    "Older resource value",
+                    "2",
+                    "2024-01-01",
+                    "",
+                    "",
+                    "",
+                ),
+                (
+                    "fact-name-new-resource",
+                    "44006677",
+                    "name",
+                    "Newer resource value",
+                    "2",
+                    "2024-01-01",
+                    "",
+                    "",
+                    "",
+                ),
+            ],
+        )
+        connection.executemany(
+            """
+            INSERT INTO fact_resource (
+                fact, resource, priority, entry_date, start_date, end_date, entry_number
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    "fact-reference",
+                    "resource-reference",
+                    "2",
+                    "2024-01-01",
+                    "2024-01-01",
+                    "",
+                    "1",
+                ),
+                (
+                    "fact-name-old-resource",
+                    "resource-old",
+                    "2",
+                    "2024-01-01",
+                    "2024-01-01",
+                    "",
+                    "1",
+                ),
+                (
+                    "fact-name-new-resource",
+                    "resource-new",
+                    "2",
+                    "2024-01-01",
+                    "2024-02-01",
+                    "",
+                    "1",
+                ),
+            ],
+        )
+
+    package.load_entities()
+
+    with sqlite3.connect(package.path) as connection:
+        name = connection.execute(
+            "select name from entity where entity = 44006677"
+        ).fetchone()[0]
+
+    assert name == "Newer resource value"
+
+
 def test_load_old_entities_entities_outside_of_range_are_removed(tmp_path):
     # create custom specification to feed in
     schema = {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR fixes the fact selection priority order used when building entities from the fact table.

[load_entities()](https://github.com/digital-land/digital-land-python/blob/c88f0a858599dd5cd5875df41e8a9cc05f1afe46/digital_land/package/dataset.py#L158) now joins facts to fact_resource and uses fact_resource.start_date as an additional tie-breaker after entity, field, priority, and fact entry date. This ensures that when multiple facts have the same priority and entry date, the value from the newer resource is selected deterministically.

Why This Is Needed

Entity rows are built by iterating through ordered facts, with later facts overwriting earlier values for the same field. 

Using fact_resource.start_date fixes that ambiguity and ensures newer resource data takes precedence when the other priority signals are equal

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Ticket Link: [ticket](https://github.com.mcas.ms/digital-land/digital-land-python/issues/509?McasTsid=11760&McasCtx=4)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

pytest tests/integration/package/test_dataset.py::test_load_entities_uses_resource_start_date_as_tiebreaker

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
