### PR TITLE
feat: use yesterdays expectations if expectation is skipped today

### DIFF
--- a/digital_land/expectations/checkpoints/dataset.py
+++ b/digital_land/expectations/checkpoints/dataset.py
@@ -1,6 +1,7 @@
 import inspect
 import json
 import logging
+import pyarrow.parquet as pq
 import spatialite
 from datetime import datetime
 from pathlib import Path
@@ -25,6 +26,7 @@ class DatasetCheckpoint(BaseCheckpoint):
         self.dataset_path = Path(file_path)
         self.organisations = organisations
         self.log = ExpectationLog(dataset=dataset)
+        self.skipped_rule_names = []
 
     def operation_factory(self, operation_string: str):
         """
@@ -115,11 +117,13 @@ class DatasetCheckpoint(BaseCheckpoint):
         expectations need parsing
         """
         self.expectations = []
+        self.skipped_rule_names = []
         today = datetime.now().strftime("%A").lower()
         for rule in rules:
             schedule = rule.get("schedule", "")
             # skip rule if today does not match scheduled day of the week.
             if schedule and schedule.lower() != today:
+                self.skipped_rule_names.append(rule["name"])
                 continue
             if rule["organisations"]:
                 rule_orgs = self.get_rule_orgs(rule)
@@ -208,4 +212,14 @@ class DatasetCheckpoint(BaseCheckpoint):
         save the outputs as a file, the file is named based the the dataset
         and stored in the provided directory
         """
+        if self.skipped_rule_names:
+            existing_path = (
+                Path(output_dir) / self.log.pq_partition / (self.dataset + ".parquet")
+            )
+            if existing_path.exists():
+                previous = pq.ParquetFile(existing_path).read().to_pylist()
+                for row in previous:
+                    if row.get("name") in self.skipped_rule_names:
+                        self.log.entries.append(row)
+
         self.log.save_parquet(output_dir)

--- a/tests/integration/expectations/checkpoints/test_dataset.py
+++ b/tests/integration/expectations/checkpoints/test_dataset.py
@@ -171,6 +171,7 @@ class TestDatasetCheckpoint:
             checkpoint.load(rules)
 
         assert len(checkpoint.expectations) == 0
+        assert "a saturday only rule" in checkpoint.skipped_rule_names
 
     def test_load_includes_rule_scheduled_for_today(self, test_organisations, mocker):
         """test loading includes rules scheduled for today, shoulld be moved to unit"""
@@ -198,6 +199,96 @@ class TestDatasetCheckpoint:
             checkpoint.load(rules)
 
         assert len(checkpoint.expectations) == 1
+
+    def test_save_carries_forward_skipped_rule_results(
+        self, tmp_path, test_organisations
+    ):
+        import pyarrow.parquet as pq
+        from digital_land.expectations.log import ExpectationLog
+
+        dataset = "test-dataset"
+        output_path = tmp_path / "expectations"
+
+        # write a previous parquet with a result for the skipped rule
+        partition_dir = output_path / f"dataset={dataset}"
+        partition_dir.mkdir(parents=True)
+        previous_log = ExpectationLog(dataset=dataset)
+        previous_log.add(
+            {
+                "organisation": "",
+                "name": "Check no duplicate geometries",
+                "operation": "duplicate_geometry_check",
+                "passed": False,
+                "message": "2 duplicates found",
+                "details": "",
+                "description": "",
+                "severity": "notice",
+                "responsibility": "internal",
+                "parameters": '{"spatial_field": "geometry"}',
+            }
+        )
+        previous_log.save_parquet(output_path)
+
+        checkpoint = DatasetCheckpoint(
+            dataset=dataset, file_path="", organisations=test_organisations
+        )
+        checkpoint.skipped_rule_names = ["Check no duplicate geometries"]
+        checkpoint.log.add(
+            {
+                "organisation": "",
+                "name": "A fresh check",
+                "passed": True,
+                "message": "passed",
+                "details": "",
+                "description": "",
+                "severity": "notice",
+                "responsibility": "internal",
+                "parameters": "{}",
+                "operation": "test",
+            }
+        )
+
+        checkpoint.save(str(output_path))
+
+        result = pq.ParquetFile(partition_dir / f"{dataset}.parquet").read().to_pylist()
+        names = [row["name"] for row in result]
+        assert "Check no duplicate geometries" in names  # carried forward
+        assert "A fresh check" in names  # fresh result preserved
+
+    def test_save_skipped_rule_no_existing_parquet(self, tmp_path, test_organisations):
+        import pyarrow.parquet as pq
+
+        dataset = "test-dataset"
+        output_path = tmp_path / "expectations"
+
+        checkpoint = DatasetCheckpoint(
+            dataset=dataset, file_path="", organisations=test_organisations
+        )
+        checkpoint.skipped_rule_names = ["some skipped rule"]
+        checkpoint.log.add(
+            {
+                "organisation": "",
+                "name": "A fresh check",
+                "passed": True,
+                "message": "passed",
+                "details": "",
+                "description": "",
+                "severity": "notice",
+                "responsibility": "internal",
+                "parameters": "{}",
+                "operation": "test",
+            }
+        )
+
+        checkpoint.save(str(output_path))
+
+        result = (
+            pq.ParquetFile(output_path / f"dataset={dataset}" / f"{dataset}.parquet")
+            .read()
+            .to_pylist()
+        )
+        assert len(result) == 1
+        assert result[0]["name"] == "A fresh check"
 
     def test_run_success(
         self, tmp_path, sqlite3_with_entity_tables_path, mocker, test_organisations


### PR DESCRIPTION
## Description

Update our expectations code so that it uses yesterdays expectations if expectation is skipped today

## Why
Currently while the pipelines run faster when the duplicate_geometry_check is only run on saturday, the outcome of those tests are only available on saturdays when we want them to be available all week. 


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Ticket Link
- This PR works in conjunction with - https://github.com/digital-land/collection-task/pull/58
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
