### PR TITLE
Fix wfs plugin paging functionality

### DIFF
--- a/digital_land/collect.py
+++ b/digital_land/collect.py
@@ -9,6 +9,7 @@ import logging
 import json
 import os
 import re
+import shutil
 from datetime import datetime
 from enum import Enum
 from timeit import default_timer as timer
@@ -19,6 +20,8 @@ from pydantic import ValidationError
 
 from .adapter.file import FileAdapter
 from .plugins.sparql import get as sparql_get
+from .plugins.wfs import WFSFileResource
+from .plugins.wfs import WFSParameters
 from .plugins.wfs import get as wfs_get
 from .plugins.arcgis import ArcGISParameters
 from .plugins.arcgis import get as arcgis_get
@@ -27,6 +30,7 @@ logger = logging.getLogger(__name__)
 
 PLUGIN_PARAMETER_MODELS = {
     "arcgis": ("ArcGIS", ArcGISParameters),
+    "wfs": ("WFS", WFSParameters),
 }
 
 
@@ -87,6 +91,20 @@ class Collector:
         )
 
     def save_content(self, content):
+        if isinstance(content, WFSFileResource):
+            hasher = hashlib.sha256()
+            with open(content.path, "rb") as f:
+                for chunk in iter(lambda: f.read(32 * 1024 * 1024), b""):
+                    hasher.update(chunk)
+
+            resource = hasher.hexdigest()
+            path = os.path.join(self.resource_dir, resource)
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            if not os.path.exists(path):
+                logging.info(path)
+                shutil.copyfile(content.path, path)
+            return resource
+
         resource = hashlib.sha256(content).hexdigest()
         path = os.path.join(self.resource_dir, resource)
         self.save(path, content)
@@ -202,6 +220,7 @@ class Collector:
                 self,
                 url,
                 log,
+                parameters=parameters,
             )
         elif plugin == "sparql":
             log, content = sparql_get(self, url, log)
@@ -220,6 +239,8 @@ class Collector:
         if content:
             try:
                 log["resource"] = self.save_content(content)
+                if isinstance(content, WFSFileResource) and content.cleanup:
+                    os.unlink(content.path)
                 return FetchStatus.OK
             except Exception as exception:
                 logging.warning(f"Failed to save data from '{url} ({exception})")
@@ -298,3 +319,4 @@ class Collector:
             logging.warning(
                 f"Invalid {plugin_name} parameters. Falling back to defaults. Errors: {exc.errors()}"
             )
+            return None

--- a/digital_land/plugins/wfs.py
+++ b/digital_land/plugins/wfs.py
@@ -4,6 +4,7 @@ import os
 import re
 import subprocess
 import tempfile
+from typing import Optional
 from urllib.parse import parse_qs, urlsplit, urlunsplit
 
 from digital_land.phase.convert import detect_encoding
@@ -25,8 +26,7 @@ strip_exps = [
 
 @dataclass(config=ConfigDict(extra="forbid"))
 class WFSParameters:
-    paging: bool = False
-    page_size: int = Field(default=DEFAULT_PAGE_SIZE, gt=0)
+    page_size: Optional[int] = Field(default=None, gt=0)
 
 
 @dataclass
@@ -50,7 +50,7 @@ def get(collector, url, log={}, plugin="wfs", parameters=None):
         )
         parameters = WFSParameters()
 
-    if parameters.paging:
+    if parameters.page_size:
         return get_paged_wfs(url, log, plugin=plugin, parameters=parameters)
 
     log, content = collector.get(url=url, log=log, plugin=plugin)
@@ -62,6 +62,7 @@ def get(collector, url, log={}, plugin="wfs", parameters=None):
 
 def get_paged_wfs(url, log, plugin="wfs", parameters=None):
     parameters = parameters or WFSParameters()
+    page_size = parameters.page_size or DEFAULT_PAGE_SIZE
     output_file = tempfile.NamedTemporaryFile(suffix=".gpkg", delete=False)
     output_path = output_file.name
     output_file.close()
@@ -76,7 +77,7 @@ def get_paged_wfs(url, log, plugin="wfs", parameters=None):
         "ON",
         "--config",
         "OGR_WFS_PAGING_PAGE_SIZE",
-        str(parameters.page_size),
+        str(page_size),
         "-f",
         "GPKG",
         output_path,

--- a/digital_land/plugins/wfs.py
+++ b/digital_land/plugins/wfs.py
@@ -1,10 +1,19 @@
 import io
+import logging
+import os
 import re
+import subprocess
+import tempfile
+from typing import Optional
 
 from digital_land.phase.convert import detect_encoding
+from pydantic import ConfigDict, Field
+from pydantic.dataclasses import dataclass
 
 
 # TBD: split this code into a WFS API plugin and a canonicalisation step
+
+DEFAULT_PAGE_SIZE = 1000
 
 
 strip_exps = [
@@ -14,15 +23,102 @@ strip_exps = [
 ]
 
 
+@dataclass(config=ConfigDict(extra="forbid"))
+class WFSParameters:
+    paging: bool = False
+    page_size: int = Field(default=DEFAULT_PAGE_SIZE, gt=0)
+    source_url: Optional[str] = None
+    layer_name: Optional[str] = None
+
+
+@dataclass
+class WFSFileResource:
+    path: str
+    cleanup: bool = True
+
+
 def strip_variable_content(content):
     for strip_exp, replacement in strip_exps:
         content = strip_exp.sub(replacement, content)
     return content
 
 
-def get(collector, url, log={}, plugin="wfs"):
+def get(collector, url, log={}, plugin="wfs", parameters=None):
+    if parameters is None:
+        parameters = WFSParameters()
+    elif not isinstance(parameters, WFSParameters):
+        logging.warning(
+            "WFS get expects parameters to be a WFSParameters instance. using default parameters"
+        )
+        parameters = WFSParameters()
+
+    if parameters.paging:
+        return get_paged_wfs(url, log, plugin=plugin, parameters=parameters)
+
     log, content = collector.get(url=url, log=log, plugin=plugin)
     encoding = detect_encoding(io.BytesIO(content))
     if encoding:
         content = strip_variable_content(content)
     return log, content
+
+
+def get_paged_wfs(url, log, plugin="wfs", parameters=None):
+    parameters = parameters or WFSParameters()
+    output_file = tempfile.NamedTemporaryFile(suffix=".gpkg", delete=False)
+    output_path = output_file.name
+    output_file.close()
+    _remove_file(output_path)
+
+    source = parameters.source_url or url
+    command = [
+        "ogr2ogr",
+        "--config",
+        "OGR_WFS_PAGING_ALLOWED",
+        "ON",
+        "--config",
+        "OGR_WFS_PAGING_PAGE_SIZE",
+        str(parameters.page_size),
+        "-f",
+        "GPKG",
+        output_path,
+        f"WFS:{source}",
+    ]
+    if parameters.layer_name:
+        command.append(parameters.layer_name)
+
+    logging.info("%s %s", plugin, url)
+
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            check=False,
+        )
+    except Exception as exception:
+        logging.warning(exception)
+        log["exception"] = type(exception).__name__
+        _remove_file(output_path)
+        return log, None
+
+    log["status"] = "200" if result.returncode == 0 else str(result.returncode)
+
+    if result.returncode != 0:
+        stderr = result.stderr.decode("utf-8", errors="replace").strip()
+        logging.warning("ogr2ogr failed (%s): %s", result.returncode, stderr)
+        log["exception"] = "CalledProcessError"
+        _remove_file(output_path)
+        return log, None
+
+    if not os.path.getsize(output_path):
+        log["exception"] = "EmptyWFSResponse"
+        _remove_file(output_path)
+        return log, None
+
+    return log, WFSFileResource(output_path)
+
+
+def _remove_file(path):
+    try:
+        os.unlink(path)
+    except OSError:
+        pass

--- a/digital_land/plugins/wfs.py
+++ b/digital_land/plugins/wfs.py
@@ -4,7 +4,7 @@ import os
 import re
 import subprocess
 import tempfile
-from typing import Optional
+from urllib.parse import parse_qs, urlsplit, urlunsplit
 
 from digital_land.phase.convert import detect_encoding
 from pydantic import ConfigDict, Field
@@ -27,8 +27,6 @@ strip_exps = [
 class WFSParameters:
     paging: bool = False
     page_size: int = Field(default=DEFAULT_PAGE_SIZE, gt=0)
-    source_url: Optional[str] = None
-    layer_name: Optional[str] = None
 
 
 @dataclass
@@ -69,7 +67,8 @@ def get_paged_wfs(url, log, plugin="wfs", parameters=None):
     output_file.close()
     _remove_file(output_path)
 
-    source = parameters.source_url or url
+    source_url, layer_name = wfs_source_and_layer(url)
+
     command = [
         "ogr2ogr",
         "--config",
@@ -81,10 +80,9 @@ def get_paged_wfs(url, log, plugin="wfs", parameters=None):
         "-f",
         "GPKG",
         output_path,
-        f"WFS:{source}",
+        f"WFS:{source_url}",
     ]
-    if parameters.layer_name:
-        command.append(parameters.layer_name)
+    command.append(layer_name)
 
     logging.info("%s %s", plugin, url)
 
@@ -115,6 +113,15 @@ def get_paged_wfs(url, log, plugin="wfs", parameters=None):
         return log, None
 
     return log, WFSFileResource(output_path)
+
+
+def wfs_source_and_layer(url):
+    parsed = urlsplit(url)
+    query = {key.lower(): value for key, value in parse_qs(parsed.query).items()}
+    values = query.get("typename") or query.get("typenames")
+    if values:
+        return urlunsplit(parsed._replace(query="")), values[0]
+    return url, ""
 
 
 def _remove_file(path):

--- a/tests/unit/plugins/test_wfs.py
+++ b/tests/unit/plugins/test_wfs.py
@@ -16,7 +16,7 @@ def test_get_falls_back_to_default_parameters_for_unvalidated_parameter_dict(cap
         log, content = wfs_get(
             FakeCollector(),
             "https://example.com/wfs",
-            parameters={"paging": True},
+            parameters={"page_size": 1000},
         )
 
     assert log["status"] == "200"
@@ -53,7 +53,7 @@ def test_get_paged_wfs_runs_ogr2ogr_with_paging_config(tmp_path, mocker):
     log, content = wfs_get(
         None,
         "https://example.com/wfs?request=GetFeature&typeName=dataset:Flood_Zones",
-        parameters=WFSParameters(paging=True, page_size=500),
+        parameters=WFSParameters(page_size=500),
     )
 
     assert isinstance(content, WFSFileResource)
@@ -99,7 +99,7 @@ def test_get_paged_wfs_derives_layer_name_from_endpoint_url(tmp_path, mocker):
     log, content = wfs_get(
         None,
         "https://example.com/wfs?request=GetFeature&typeName=dataset:Flood_Zones&outputFormat=Geopackage",
-        parameters=WFSParameters(paging=True),
+        parameters=WFSParameters(page_size=1000),
     )
 
     assert isinstance(content, WFSFileResource)
@@ -108,6 +108,7 @@ def test_get_paged_wfs_derives_layer_name_from_endpoint_url(tmp_path, mocker):
         "WFS:https://example.com/wfs",
         "dataset:Flood_Zones",
     ]
+    assert "1000" in captured["command"]
 
 
 def test_wfs_source_and_layer_extracts_case_insensitive_typename():
@@ -141,7 +142,7 @@ def test_get_paged_wfs_logs_failure_and_cleans_temp_file(tmp_path, mocker):
     log, content = wfs_get(
         None,
         "https://example.com/wfs",
-        parameters=WFSParameters(paging=True),
+        parameters=WFSParameters(page_size=1000),
     )
 
     assert content is None

--- a/tests/unit/plugins/test_wfs.py
+++ b/tests/unit/plugins/test_wfs.py
@@ -1,0 +1,142 @@
+from subprocess import CompletedProcess
+
+from digital_land.plugins.wfs import WFSFileResource
+from digital_land.plugins.wfs import WFSParameters
+from digital_land.plugins.wfs import get as wfs_get
+
+
+def test_get_falls_back_to_default_parameters_for_unvalidated_parameter_dict(caplog):
+    class FakeCollector:
+        def get(self, url, log, plugin):
+            log["status"] = "200"
+            return log, b"reference"
+
+    with caplog.at_level("WARNING"):
+        log, content = wfs_get(
+            FakeCollector(),
+            "https://example.com/wfs",
+            parameters={"paging": True},
+        )
+
+    assert log["status"] == "200"
+    assert content == b"reference"
+    assert (
+        "WFS get expects parameters to be a WFSParameters instance. using default parameters"
+        in caplog.text
+    )
+
+
+def test_get_paged_wfs_runs_ogr2ogr_with_paging_config(tmp_path, mocker):
+    output_path = tmp_path / "output.gpkg"
+    captured = {}
+
+    class FakeTempFile:
+        name = str(output_path)
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def close(self):
+            pass
+
+    def fake_run(command, capture_output, check):
+        captured["command"] = command
+        captured["capture_output"] = capture_output
+        captured["check"] = check
+        output_path.write_bytes(b"geopackage")
+        return CompletedProcess(command, 0, stdout=b"", stderr=b"")
+
+    mocker.patch("digital_land.plugins.wfs.tempfile.NamedTemporaryFile", FakeTempFile)
+    mocker.patch("digital_land.plugins.wfs.subprocess.run", side_effect=fake_run)
+
+    log, content = wfs_get(
+        None,
+        "https://example.com/wfs?request=GetFeature",
+        parameters=WFSParameters(paging=True, page_size=500),
+    )
+
+    assert isinstance(content, WFSFileResource)
+    assert content.path == str(output_path)
+    assert log["status"] == "200"
+    assert captured["command"] == [
+        "ogr2ogr",
+        "--config",
+        "OGR_WFS_PAGING_ALLOWED",
+        "ON",
+        "--config",
+        "OGR_WFS_PAGING_PAGE_SIZE",
+        "500",
+        "-f",
+        "GPKG",
+        str(output_path),
+        "WFS:https://example.com/wfs?request=GetFeature",
+    ]
+
+def test_get_paged_wfs_logs_failure_and_cleans_temp_file(tmp_path, mocker):
+    output_path = tmp_path / "output.gpkg"
+
+    class FakeTempFile:
+        name = str(output_path)
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def close(self):
+            pass
+
+    def fake_run(command, capture_output, check):
+        output_path.write_bytes(b"partial")
+        return CompletedProcess(command, 1, stdout=b"", stderr=b"failed")
+
+    mocker.patch("digital_land.plugins.wfs.tempfile.NamedTemporaryFile", FakeTempFile)
+    mocker.patch("digital_land.plugins.wfs.subprocess.run", side_effect=fake_run)
+
+    log, content = wfs_get(
+        None,
+        "https://example.com/wfs",
+        parameters=WFSParameters(paging=True),
+    )
+
+    assert content is None
+    assert log["status"] == "1"
+    assert log["exception"] == "CalledProcessError"
+    assert not output_path.exists()
+
+
+def test_get_paged_wfs_can_use_source_url_override_and_layer_name(tmp_path, mocker):
+    output_path = tmp_path / "output.gpkg"
+    captured = {}
+
+    class FakeTempFile:
+        name = str(output_path)
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def close(self):
+            pass
+
+    def fake_run(command, capture_output, check):
+        captured["command"] = command
+        output_path.write_bytes(b"geopackage")
+        return CompletedProcess(command, 0, stdout=b"", stderr=b"")
+
+    mocker.patch("digital_land.plugins.wfs.tempfile.NamedTemporaryFile", FakeTempFile)
+    mocker.patch("digital_land.plugins.wfs.subprocess.run", side_effect=fake_run)
+
+    log, content = wfs_get(
+        None,
+        "https://example.com/wfs?request=GetFeature&typeName=ignored",
+        parameters=WFSParameters(
+            paging=True,
+            source_url="https://example.com/wfs",
+            layer_name="dataset:Flood_Zones",
+        ),
+    )
+
+    assert isinstance(content, WFSFileResource)
+    assert log["status"] == "200"
+    assert captured["command"][-2:] == [
+        "WFS:https://example.com/wfs",
+        "dataset:Flood_Zones",
+    ]

--- a/tests/unit/plugins/test_wfs.py
+++ b/tests/unit/plugins/test_wfs.py
@@ -3,6 +3,7 @@ from subprocess import CompletedProcess
 from digital_land.plugins.wfs import WFSFileResource
 from digital_land.plugins.wfs import WFSParameters
 from digital_land.plugins.wfs import get as wfs_get
+from digital_land.plugins.wfs import wfs_source_and_layer
 
 
 def test_get_falls_back_to_default_parameters_for_unvalidated_parameter_dict(caplog):
@@ -51,7 +52,7 @@ def test_get_paged_wfs_runs_ogr2ogr_with_paging_config(tmp_path, mocker):
 
     log, content = wfs_get(
         None,
-        "https://example.com/wfs?request=GetFeature",
+        "https://example.com/wfs?request=GetFeature&typeName=dataset:Flood_Zones",
         parameters=WFSParameters(paging=True, page_size=500),
     )
 
@@ -69,8 +70,54 @@ def test_get_paged_wfs_runs_ogr2ogr_with_paging_config(tmp_path, mocker):
         "-f",
         "GPKG",
         str(output_path),
-        "WFS:https://example.com/wfs?request=GetFeature",
+        "WFS:https://example.com/wfs",
+        "dataset:Flood_Zones",
     ]
+
+
+def test_get_paged_wfs_derives_layer_name_from_endpoint_url(tmp_path, mocker):
+    output_path = tmp_path / "output.gpkg"
+    captured = {}
+
+    class FakeTempFile:
+        name = str(output_path)
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def close(self):
+            pass
+
+    def fake_run(command, capture_output, check):
+        captured["command"] = command
+        output_path.write_bytes(b"geopackage")
+        return CompletedProcess(command, 0, stdout=b"", stderr=b"")
+
+    mocker.patch("digital_land.plugins.wfs.tempfile.NamedTemporaryFile", FakeTempFile)
+    mocker.patch("digital_land.plugins.wfs.subprocess.run", side_effect=fake_run)
+
+    log, content = wfs_get(
+        None,
+        "https://example.com/wfs?request=GetFeature&typeName=dataset:Flood_Zones&outputFormat=Geopackage",
+        parameters=WFSParameters(paging=True),
+    )
+
+    assert isinstance(content, WFSFileResource)
+    assert log["status"] == "200"
+    assert captured["command"][-2:] == [
+        "WFS:https://example.com/wfs",
+        "dataset:Flood_Zones",
+    ]
+
+
+def test_wfs_source_and_layer_extracts_case_insensitive_typename():
+    source_url, layer_name = wfs_source_and_layer(
+        "https://example.com/wfs?request=GetFeature&TYPENAME=dataset:Flood_Zones"
+    )
+
+    assert source_url == "https://example.com/wfs"
+    assert layer_name == "dataset:Flood_Zones"
+
 
 def test_get_paged_wfs_logs_failure_and_cleans_temp_file(tmp_path, mocker):
     output_path = tmp_path / "output.gpkg"
@@ -101,42 +148,3 @@ def test_get_paged_wfs_logs_failure_and_cleans_temp_file(tmp_path, mocker):
     assert log["status"] == "1"
     assert log["exception"] == "CalledProcessError"
     assert not output_path.exists()
-
-
-def test_get_paged_wfs_can_use_source_url_override_and_layer_name(tmp_path, mocker):
-    output_path = tmp_path / "output.gpkg"
-    captured = {}
-
-    class FakeTempFile:
-        name = str(output_path)
-
-        def __init__(self, *args, **kwargs):
-            pass
-
-        def close(self):
-            pass
-
-    def fake_run(command, capture_output, check):
-        captured["command"] = command
-        output_path.write_bytes(b"geopackage")
-        return CompletedProcess(command, 0, stdout=b"", stderr=b"")
-
-    mocker.patch("digital_land.plugins.wfs.tempfile.NamedTemporaryFile", FakeTempFile)
-    mocker.patch("digital_land.plugins.wfs.subprocess.run", side_effect=fake_run)
-
-    log, content = wfs_get(
-        None,
-        "https://example.com/wfs?request=GetFeature&typeName=ignored",
-        parameters=WFSParameters(
-            paging=True,
-            source_url="https://example.com/wfs",
-            layer_name="dataset:Flood_Zones",
-        ),
-    )
-
-    assert isinstance(content, WFSFileResource)
-    assert log["status"] == "200"
-    assert captured["command"][-2:] == [
-        "WFS:https://example.com/wfs",
-        "dataset:Flood_Zones",
-    ]

--- a/tests/unit/test_collect.py
+++ b/tests/unit/test_collect.py
@@ -12,6 +12,8 @@ import requests
 
 from digital_land.collect import Collector, FetchStatus
 from digital_land.plugins.arcgis import ArcGISParameters
+from digital_land.plugins.wfs import WFSFileResource
+from digital_land.plugins.wfs import WFSParameters
 
 
 @pytest.fixture
@@ -243,6 +245,49 @@ def test_fetch_passes_parameters_to_arcgis_plugin(collector, mocker):
     assert status == FetchStatus.OK
     assert captured["url"] == url
     assert captured["parameters"] == ArcGISParameters(max_page_size=20)
+
+
+def test_fetch_passes_parameters_to_wfs_plugin(collector, mocker):
+    captured = {}
+
+    def fake_wfs_get(collector_obj, url, log, parameters=None, plugin="wfs"):
+        captured["collector"] = collector_obj
+        captured["url"] = url
+        captured["parameters"] = parameters
+        return log, b"wfs data"
+
+    mocker.patch("digital_land.collect.wfs_get", side_effect=fake_wfs_get)
+
+    url = "http://some.wfs.url"
+    status, log = collector.fetch(
+        url,
+        endpoint=sha_digest(url),
+        plugin="wfs",
+        parameters={"paging": True, "page_size": 500},
+        refill_todays_logs=True,
+    )
+
+    assert status == FetchStatus.OK
+    assert captured["url"] == url
+    assert captured["parameters"] == WFSParameters(paging=True, page_size=500)
+
+
+def test_save_resource_saves_file_resource_without_loading_content(collector, tmp_path):
+    source_path = tmp_path / "source.gpkg"
+    source_path.write_bytes(b"geopackage")
+
+    log = {}
+    status = collector.save_resource(
+        WFSFileResource(str(source_path)),
+        "http://some.wfs.url",
+        log,
+    )
+
+    resource_path = pathlib.Path(collector.resource_dir) / log["resource"]
+
+    assert status == FetchStatus.OK
+    assert resource_path.read_bytes() == b"geopackage"
+    assert not source_path.exists()
 
 
 def test_collect_reads_parameters_from_csv(tmp_path, mocker):

--- a/tests/unit/test_collect.py
+++ b/tests/unit/test_collect.py
@@ -263,13 +263,13 @@ def test_fetch_passes_parameters_to_wfs_plugin(collector, mocker):
         url,
         endpoint=sha_digest(url),
         plugin="wfs",
-        parameters={"paging": True, "page_size": 500},
+        parameters={"page_size": 500},
         refill_todays_logs=True,
     )
 
     assert status == FetchStatus.OK
     assert captured["url"] == url
-    assert captured["parameters"] == WFSParameters(paging=True, page_size=500)
+    assert captured["parameters"] == WFSParameters(page_size=500)
 
 
 def test_save_resource_saves_file_resource_without_loading_content(collector, tmp_path):


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Currently, we cannot download the full WFS dataset because the endpoint response is capped at around 300k records (~120mb). The complete dataset is approximately 12 million records (5.5GB).

We need to implement WFS paging so the collector can retrieve and store the full dataset. Implementation details below.

- Extend the existing WFS plugin with optional typed parameters, following the existing ArcGIS plugin pattern.
- Keep current WFS behaviour unchanged by default.
- When 'page_size' is given, use GDAL 'ogr2ogr' to download the WFS layer with paging enabled and write it to a temporary GeoPackage.
- Derive the WFS layer name from the existing 'typeName'/'typeNames' value in endpoint-url.
- Return a 'WFSFileResource' from the plugin so the collector can save the generated file without loading it into memory.
- Update 'Collector.save_content()' to explicitly handle WFSFileResource by hashing/copying the file in chunks, while preserving existing byte-based behaviour.
- Add unit tests for WFS parameter handling, 'ogr2ogr' command construction, failure cleanup, and collector file-resource saving.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Ticket Link: [ticket](https://github.com.mcas.ms/orgs/digital-land/projects/15/views/1?filterQuery=&pane=issue&itemId=125941014&issue=digital-land%7Cconfig%7C590)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
