### PR TITLE
Raise missing associated entity issue for plan-timetable

### DIFF
--- a/digital_land/phase/lookup.py
+++ b/digital_land/phase/lookup.py
@@ -172,11 +172,17 @@ class EntityLookupPhase(LookupPhase):
 
 class FactLookupPhase(LookupPhase):
     def __init__(
-        self, lookups={}, redirect_lookups={}, issue_log=None, odp_collections=[]
+        self,
+        lookups={},
+        redirect_lookups={},
+        issue_log=None,
+        odp_collections=None,
+        package_prefixes=None,
     ):
         super().__init__(lookups, redirect_lookups, issue_log)
         self.entity_field = "reference-entity"
         self.odp_collections = odp_collections
+        self.package_prefixes = package_prefixes or {}
 
     def process(self, stream):
         for block in stream:
@@ -211,11 +217,28 @@ class FactLookupPhase(LookupPhase):
                 # as it is organisation specific.
                 find_entity = self.check_associated_organisation(find_entity)
 
+            for package_prefix in self.package_prefixes.get(prefix, []):
+                if find_entity:
+                    break
+
+                find_entity = self.lookup(
+                    prefix=package_prefix,
+                    organisation=organisation,
+                    reference=reference,
+                )
+                if not find_entity:
+                    find_entity = self.lookup(
+                        prefix=package_prefix, reference=reference
+                    )
+                    find_entity = self.check_associated_organisation(find_entity)
+
             if not find_entity or (
                 str(find_entity) in self.redirect_lookups
                 and int(self.redirect_lookups[str(find_entity)].get("status", 0)) == 410
             ):
-                if self.odp_collections and prefix in self.odp_collections:
+                if (self.odp_collections and prefix in self.odp_collections) or (
+                    prefix in self.package_prefixes
+                ):
                     self.issues.log_issue(
                         prefix,
                         "missing associated entity",

--- a/digital_land/pipeline/main.py
+++ b/digital_land/pipeline/main.py
@@ -690,6 +690,7 @@ class Pipeline:
                     redirect_lookups=redirect_lookups,
                     issue_log=self.issue_log,
                     odp_collections=self.specification.get_odp_collections(),
+                    package_prefixes=self.specification.get_package_prefixes(),
                 ),
                 FactPrunePhase(),
                 SavePhase(

--- a/digital_land/specification.py
+++ b/digital_land/specification.py
@@ -319,6 +319,16 @@ class Specification:
     def get_field_prefix_map(self):
         return {key: self.field_prefix(key) for key in self.field.keys()}
 
+    def get_package_prefixes(self):
+        return {
+            "plan": [
+                "local-plan",
+                "minerals-plan",
+                "waste-plan",
+                "supplementary-plan",
+            ],
+        }
+
     def get_dataset_typology(self, dataset):
         if dataset:
             return self.dataset[dataset]["typology"]

--- a/tests/unit/phase/test_lookup.py
+++ b/tests/unit/phase/test_lookup.py
@@ -314,3 +314,69 @@ class TestFactLookupPhase:
 
         assert output[0]["row"]["reference-entity"] == "1"
         assert len(issues.rows) == 0
+
+    def test_package_prefix_lookup_assigns_reference_entity(self):
+        input_stream = [
+            {
+                "organisation": "local-authorityabc",
+                "row": {
+                    "fact": "abc",
+                    "entity": "10",
+                    "field": "plan",
+                    "value": "local-plan-1",
+                    "prefix": "plan",
+                    "reference": "local-plan-1",
+                    "entry-number": 1,
+                    "line-number": 2,
+                },
+            }
+        ]
+        lookups = {
+            ",local-plan,local-plan-1,local-authorityabc": "1",
+            ",plan-timetable,1,local-authorityabc": "10",
+        }
+        issues = IssueLog()
+
+        phase = FactLookupPhase(
+            lookups=lookups,
+            issue_log=issues,
+            package_prefixes={"plan": ["local-plan"]},
+        )
+        output = [block for block in phase.process(input_stream)]
+
+        assert output[0]["row"]["reference-entity"] == "1"
+        assert len(issues.rows) == 0
+
+    def test_package_prefix_lookup_raises_missing_associated_entity(self):
+        input_stream = [
+            {
+                "organisation": "local-authorityabc",
+                "row": {
+                    "fact": "abc",
+                    "entity": "10",
+                    "field": "plan",
+                    "value": "missing-plan",
+                    "prefix": "plan",
+                    "reference": "missing-plan",
+                    "entry-number": 1,
+                    "line-number": 2,
+                },
+            }
+        ]
+        lookups = {
+            ",local-plan,other-plan,local-authorityabc": "1",
+            ",plan-timetable,1,local-authorityabc": "10",
+        }
+        issues = IssueLog()
+
+        phase = FactLookupPhase(
+            lookups=lookups,
+            issue_log=issues,
+            package_prefixes={"plan": ["local-plan"]},
+        )
+        output = [block for block in phase.process(input_stream)]
+
+        assert "reference-entity" not in output[0]["row"]
+        assert issues.rows[0]["field"] == "plan"
+        assert issues.rows[0]["issue-type"] == "missing associated entity"
+        assert issues.rows[0]["value"] == "missing-plan"

--- a/tests/unit/test_specification.py
+++ b/tests/unit/test_specification.py
@@ -227,3 +227,15 @@ def test_get_field_prefix_map_returns_correct_values(input, expected):
     spec = Specification()
     spec.field = input
     assert expected == spec.get_field_prefix_map()
+
+
+def test_get_package_prefixes_returns_plan_package_prefixes():
+    spec = Specification()
+    assert spec.get_package_prefixes() == {
+        "plan": [
+            "local-plan",
+            "minerals-plan",
+            "waste-plan",
+            "supplementary-plan",
+        ],
+    }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Raise missing associated entity issue for plan-timetable.
Because plan is a package dataset rather than a concrete resource/dataset, issue-type is not raise when there is a missing association entity. We need to adjust the specification to lookup in the resource that Plan was made from and report a missing association entity if none matched just like other normal resource.

Change details as follow

digital_land/phase/lookup.py
- Added package_prefixes support to FactLookupPhase, fallback lookup through package prefixes, and missing associated entity logging for package roots like plan.

digital-land-python/digital_land/pipeline/main.py
- Passes self.specification.get_package_prefixes() into FactLookupPhase.

digital-land-python/digital_land/specification.py
- Added get_package_prefixes() with the plan -> local-plan/minerals-plan/waste-plan/supplementary-plan mapping.
test_lookup.py 
- Added unit tests for package prefix lookup resolving and missing associated entity issue logging.
test_specification.py
- Added unit test for the package prefix mapping.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com.mcas.ms/digital-land/config/issues/2601?McasTsid=11760&McasCtx=4)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

This was tested by  running local-plan collection locally and one example of the resource that raise a missing association entity is 

dataset,resource,line-number,entry-number,field,entity,issue-type,value,message
plan-timetable,95b1fb985e0573bc4a658c3d9980716d0a66c37db750ca5a71b4a3b8875b2e9f,2,1,plan,5109768,missing associated entity,county-durham-plan,

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
