### PR TITLE
fix: handle edge case where two end points provide same resource which efers two 2 datasets

### DIFF
--- a/digital_land/collection.py
+++ b/digital_land/collection.py
@@ -187,9 +187,13 @@ class ResourceLogStore(CSVStore):
 
                 for entry in source.records[endpoint]:
                     organisations.add(entry["organisation"])
-                    datasets = set(
-                        entry.get("datasets", entry.get("pipelines", "")).split(";")
-                    )
+                    datasets |= {
+                        dataset
+                        for dataset in entry.get(
+                            "datasets", entry.get("pipelines", "")
+                        ).split(";")
+                        if dataset
+                    }
 
             new_entries[key] = {
                 "bytes": resource["bytes"],
@@ -227,11 +231,14 @@ class ResourceLogStore(CSVStore):
                 for endpoint in entry["endpoints"].split(";"):
                     for r_source in source.records[endpoint]:
                         organisations.add(r_source["organisation"])
-                        datasets = set(
-                            r_source.get(
+                        datasets |= {
+                            dataset
+                            for dataset in r_source.get(
                                 "datasets", r_source.get("pipelines", "")
                             ).split(";")
-                        )
+                            if dataset
+                        }
+
                 entry["organisations"] = ";".join(sorted(organisations))
                 entry["datasets"] = ";".join(sorted(datasets))
 

--- a/tests/unit/test_collection.py
+++ b/tests/unit/test_collection.py
@@ -118,3 +118,97 @@ def test_endpoint_source_mismatch():
     resource = ResourceLogStore(Schema("resource"))
     with pytest.raises(RuntimeError):
         resource.load(log, source)
+
+
+def test_resource_shared_by_two_endpoints_gets_both_datasets():
+    """A resource collected from two endpoints that feed DIFFERENT datasets
+    must be recorded against BOTH datasets (the Adur A4D/A4DA edge case).
+
+    Regression guard: `datasets` used to be overwritten per-endpoint instead
+    of accumulated, so only the last-visited endpoint's dataset survived.
+    """
+    # the same resource hash collected from two different endpoints
+    log = LogStore(Schema("log"))
+    for endpoint in ["endpoint-a4da", "endpoint-a4d"]:
+        log.add_entry(
+            {
+                "endpoint": endpoint,
+                "entry-date": "2025-01-06",
+                "resource": "shared-resource",
+                "bytes": "1024",
+            }
+        )
+
+    # each endpoint feeds a different dataset
+    source = CSVStore(Schema("source"))
+    source.add_entry(
+        {
+            "endpoint": "endpoint-a4da",
+            "organisation": "test-org",
+            "pipelines": "article-4-direction-area",
+        }
+    )
+    source.add_entry(
+        {
+            "endpoint": "endpoint-a4d",
+            "organisation": "test-org",
+            "pipelines": "article-4-direction",
+        }
+    )
+
+    resource = ResourceLogStore(Schema("resource"))
+    resource.load(log, source)
+
+    assert len(resource.entries) == 1
+    entry = resource.entries[0]
+    assert entry["resource"] == "shared-resource"
+    # both datasets present, not just the last endpoint visited
+    assert set(entry["datasets"].split(";")) == {
+        "article-4-direction",
+        "article-4-direction-area",
+    }
+    # endpoints were already accumulated correctly - guard against regression
+    assert set(entry["endpoints"].split(";")) == {"endpoint-a4da", "endpoint-a4d"}
+
+
+def test_existing_resource_datasets_recomputed_from_all_endpoints():
+    """The config-change branch (updating an existing resource entry) must also
+    accumulate datasets across all of a resource's endpoints, not overwrite."""
+    source = CSVStore(Schema("source"))
+    source.add_entry(
+        {
+            "endpoint": "endpoint-a4da",
+            "organisation": "test-org",
+            "pipelines": "article-4-direction-area",
+        }
+    )
+    source.add_entry(
+        {
+            "endpoint": "endpoint-a4d",
+            "organisation": "test-org",
+            "pipelines": "article-4-direction",
+        }
+    )
+
+    resource = ResourceLogStore(Schema("resource"))
+    # pre-existing entry from both endpoints but with a stale, single dataset
+    resource.add_entry(
+        {
+            "resource": "shared-resource",
+            "bytes": "1024",
+            "endpoints": "endpoint-a4da;endpoint-a4d",
+            "organisations": "test-org",
+            "datasets": "article-4-direction-area",
+            "start-date": "2025-01-06",
+            "end-date": "",
+        }
+    )
+
+    # empty log -> the existing entry takes the config-recompute (else) branch
+    resource.load(LogStore(Schema("log")), source)
+
+    entry = next(e for e in resource.entries if e["resource"] == "shared-resource")
+    assert set(entry["datasets"].split(";")) == {
+        "article-4-direction",
+        "article-4-direction-area",
+    }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When the collection process records which **dataset(s)** are contained in what **resource** it was *overwriting* that list instead of *adding* to it whenever a resource came from more than one endpoint. So if a resource contained several datasets, only the last one survived and the rest were lost.

We changed it to **add each dataset to the list rather than replace it**, so a resource that belongs to more than one dataset now keeps all of them. The same small fix was applied in the two places that build this record (one for brand-new files, one for updating existing ones), and we added unit tests covering both.

## Why

A resource is identified by a fingerprint of its contents.

If two different URLs serve a file with identical contents, the system correctly treats them as the **same resource**.

Adur is the first case we've hit where **two different endpoints feed two different datasets but happen to serve the identical file** — their A4D and A4DA URLs return the same data. The correct record is "this file belongs to *both*
article-4-direction *and* article-4-direction-area." But because of the overwrite bug, the file ended up recorded against only **one** of them (and which one was essentially random, depending on processing order).

That single-dataset record then flows through to datasette, and the submit service uses it to work out which dataset a file belongs to. With a dataset missing, the Adur task showed up in some views but not others and wasn't clickable from the task list. This fix makes the file correctly belong to both datasets, so the task resolves properly.

(Note: this corrects how the record is generated going forward — the Adur data fixes itself the next time that collection runs and regenerates its files. No manual backfill is needed.)


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com/digital-land/digital-land-python/issues/568)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

## How we know it's safe

Ran a before/after comparison of the regenerated records on the real DEV
`article-4-direction` collection (346 resources):
- Only **3 of 346** resources changed.
- Every change was **additive** — a file that had one dataset now correctly has
  both. No file *lost* a dataset, no endpoints changed, no rows added or removed.
- The 3 changed resources are exactly the shared-file edge case (including the
  resource from the original bug report). The other 343 were untouched.

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
