### PR TITLE
specification class to have optional cloud path s3

### DIFF
--- a/digital_land/log.py
+++ b/digital_land/log.py
@@ -127,12 +127,12 @@ class IssueLog(Log):
                 if entity:
                     row["entity"] = entity
 
-    def add_severity_column(self, severity_mapping_path):
-        # Load only the 'severity' column from severity_mapping
-        severity_mapping = pd.read_csv(
-            severity_mapping_path,
-            usecols=["issue-type", "severity", "description", "responsibility"],
-        )
+    def add_severity_column(self, severity_mapping_path=None, severity_mapping=None):
+        if severity_mapping is None:
+            severity_mapping = pd.read_csv(
+                severity_mapping_path,
+                usecols=["issue-type", "severity", "description", "responsibility"],
+            )
 
         # Convert the existing log data to a DataFrame
         log_df = pd.DataFrame(self.rows)

--- a/digital_land/log.py
+++ b/digital_land/log.py
@@ -139,7 +139,14 @@ class IssueLog(Log):
                 usecols=["issue-type", "severity", "description", "responsibility"],
             )
         elif isinstance(severity_mapping, dict):
-            severity_mapping = pd.DataFrame(list(severity_mapping.values()))
+            # Convert the dictionary to a DataFrame, keeping only relevant cols
+            _cols = {"issue-type", "severity", "description", "responsibility"}
+            severity_mapping = pd.DataFrame(
+                [
+                    {k: v for k, v in row.items() if k in _cols}
+                    for row in severity_mapping.values()
+                ]
+            )
 
         # Convert the existing log data to a DataFrame
         log_df = pd.DataFrame(self.rows)

--- a/digital_land/log.py
+++ b/digital_land/log.py
@@ -128,6 +128,7 @@ class IssueLog(Log):
                     row["entity"] = entity
 
     def add_severity_column(self, severity_mapping_path=None, severity_mapping=None):
+        # Load only the 'severity' column from severity_mapping, optional path if Specifiaction has already loaded it
         if severity_mapping is None:
             severity_mapping = pd.read_csv(
                 severity_mapping_path,

--- a/digital_land/log.py
+++ b/digital_land/log.py
@@ -129,11 +129,17 @@ class IssueLog(Log):
 
     def add_severity_column(self, severity_mapping_path=None, severity_mapping=None):
         # Load only the 'severity' column from severity_mapping, optional path if Specifiaction has already loaded it
+        if severity_mapping is None and severity_mapping_path is None:
+            raise ValueError(
+                "Either severity_mapping_path or severity_mapping must be provided"
+            )
         if severity_mapping is None:
             severity_mapping = pd.read_csv(
                 severity_mapping_path,
                 usecols=["issue-type", "severity", "description", "responsibility"],
             )
+        elif isinstance(severity_mapping, dict):
+            severity_mapping = pd.DataFrame(list(severity_mapping.values()))
 
         # Convert the existing log data to a DataFrame
         log_df = pd.DataFrame(self.rows)

--- a/digital_land/specification.py
+++ b/digital_land/specification.py
@@ -389,6 +389,7 @@ class Specification:
             "provision-rule.csv",
             "schema.csv",
             "schema-field.csv",
+            "issue-type.csv",
         ]
         for specification_csv in specification_csvs:
             urllib.request.urlretrieve(

--- a/digital_land/specification.py
+++ b/digital_land/specification.py
@@ -4,8 +4,6 @@ from datetime import datetime
 import logging
 import warnings
 import urllib.request
-import pandas as pd
-
 from pathlib import Path
 from cloudpathlib import AnyPath
 
@@ -134,10 +132,13 @@ class Specification:
                 self.odp_collections.append(row["specification"])
 
     def load_issue_type(self, path):
-        self.issue_type = pd.read_csv(
-            (path / "issue-type.csv").open(),
-            usecols=["issue-type", "severity", "description", "responsibility"],
-        )
+        # try/except to handle as this file is not always present
+        try:
+            with (path / "issue-type.csv").open() as f:
+                reader = csv.DictReader(f)
+                self.issue_type = {row["issue-type"]: row for row in reader}
+        except FileNotFoundError:
+            self.issue_type = {}
 
     def index_schema(self):
         self.schema_dataset = {}

--- a/digital_land/specification.py
+++ b/digital_land/specification.py
@@ -4,6 +4,7 @@ from datetime import datetime
 import logging
 import warnings
 import urllib.request
+import pandas as pd
 
 from pathlib import Path
 from cloudpathlib import AnyPath
@@ -133,8 +134,6 @@ class Specification:
                 self.odp_collections.append(row["specification"])
 
     def load_issue_type(self, path):
-        import pandas as pd
-
         self.issue_type = pd.read_csv(
             (path / "issue-type.csv").open(),
             usecols=["issue-type", "severity", "description", "responsibility"],

--- a/digital_land/specification.py
+++ b/digital_land/specification.py
@@ -6,6 +6,7 @@ import warnings
 import urllib.request
 
 from pathlib import Path
+from cloudpathlib import AnyPath
 
 from .datatype.address import AddressDataType
 from .datatype.datatype import DataType
@@ -28,7 +29,7 @@ specification_path = os.path.join(
 
 class Specification:
     def __init__(self, path="specification"):
-        self.path = path
+        self.path = AnyPath(path)
         self.dataset = {}
         self.dataset_names = []
         self.schema = {}
@@ -45,54 +46,55 @@ class Specification:
         self.pipeline = {}
         self.licence = {}
         self.odp_collections = []
-        self.load_dataset(path)
-        self.load_schema(path)
-        self.load_dataset_schema(path)
-        self.load_datatype(path)
-        self.load_field(path)
-        self.load_schema_field(path)
-        self.load_typology(path)
-        self.load_pipeline(path)
-        self.load_dataset_field(path)
-        self.load_licence(path)
-        self.load_odp_collections(path)
+        self.load_dataset(self.path)
+        self.load_schema(self.path)
+        self.load_dataset_schema(self.path)
+        self.load_datatype(self.path)
+        self.load_field(self.path)
+        self.load_schema_field(self.path)
+        self.load_typology(self.path)
+        self.load_pipeline(self.path)
+        self.load_dataset_field(self.path)
+        self.load_licence(self.path)
+        self.load_odp_collections(self.path)
+        self.load_issue_type(self.path)
 
         self.index_field()
         self.index_schema()
 
     def load_dataset(self, path):
-        reader = csv.DictReader(open(os.path.join(path, "dataset.csv")))
+        reader = csv.DictReader((path / "dataset.csv").open())
         for row in reader:
             self.dataset_names.append(row["dataset"])
             self.dataset[row["dataset"]] = row
 
     def load_schema(self, path):
-        reader = csv.DictReader(open(os.path.join(path, "schema.csv")))
+        reader = csv.DictReader((path / "schema.csv").open())
         for row in reader:
             self.schema_names.append(row["schema"])
             self.schema[row["schema"]] = row
             self.schema[row["schema"]].setdefault("fields", [])
 
     def load_dataset_schema(self, path):
-        reader = csv.DictReader(open(os.path.join(path, "dataset-schema.csv")))
+        reader = csv.DictReader((path / "dataset-schema.csv").open())
         for row in reader:
             schemas = self.dataset_schema.setdefault(row["dataset"], [])
             schemas.append(row["schema"])
 
     def load_datatype(self, path):
-        reader = csv.DictReader(open(os.path.join(path, "datatype.csv")))
+        reader = csv.DictReader((path / "datatype.csv").open())
         for row in reader:
             self.datatype_names.append(row["datatype"])
             self.datatype[row["datatype"]] = row
 
     def load_field(self, path):
-        reader = csv.DictReader(open(os.path.join(path, "field.csv")))
+        reader = csv.DictReader((path / "field.csv").open())
         for row in reader:
             self.field_names.append(row["field"])
             self.field[row["field"]] = row
 
     def load_dataset_field(self, path):
-        reader = csv.DictReader(open(os.path.join(path, "dataset-field.csv")))
+        reader = csv.DictReader((path / "dataset-field.csv").open())
         for row in reader:
             dataset = row["dataset"]
             field = row["field"]
@@ -103,32 +105,40 @@ class Specification:
             self.dataset_field_dataset[dataset][field] = row["field-dataset"]
 
     def load_schema_field(self, path):
-        reader = csv.DictReader(open(os.path.join(path, "schema-field.csv")))
+        reader = csv.DictReader((path / "schema-field.csv").open())
         for row in reader:
             self.schema_field.setdefault(row["schema"], [])
             self.schema_field[row["schema"]].append(row["field"])
             self.schema[row["schema"]]["fields"].append(row["field"])
 
     def load_typology(self, path):
-        reader = csv.DictReader(open(os.path.join(path, "typology.csv")))
+        reader = csv.DictReader((path / "typology.csv").open())
         for row in reader:
             self.typology[row["typology"]] = row
 
     def load_pipeline(self, path):
-        reader = csv.DictReader(open(os.path.join(path, "pipeline.csv")))
+        reader = csv.DictReader((path / "pipeline.csv").open())
         for row in reader:
             self.pipeline[row["pipeline"]] = row
 
     def load_licence(self, path):
-        reader = csv.DictReader(open(os.path.join(path, "licence.csv")))
+        reader = csv.DictReader((path / "licence.csv").open())
         for row in reader:
             self.licence[row["licence"]] = row
 
     def load_odp_collections(self, path):
-        reader = csv.DictReader(open(os.path.join(path, "provision-rule.csv")))
+        reader = csv.DictReader((path / "provision-rule.csv").open())
         for row in reader:
             if row["project"] == "open-digital-planning":
                 self.odp_collections.append(row["specification"])
+
+    def load_issue_type(self, path):
+        import pandas as pd
+
+        self.issue_type = pd.read_csv(
+            (path / "issue-type.csv").open(),
+            usecols=["issue-type", "severity", "description", "responsibility"],
+        )
 
     def index_schema(self):
         self.schema_dataset = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "pyarrow",
     "pygit2",
     "boto3",
+    "cloudpathlib[s3]",
     "moto",
     "psutil",
     "polars",


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR migrates Specification to use cloudpathlib.AnyPath so it can load specification files directly from S3 as well as local paths. It also adds pre load to issue-type.csv, this allows async to not have to try and import cloudpathlib as well.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Ticket Link https://github.com/digital-land/async-request-backend/issues/109

## QA Instructions, Screenshots, Recordings

Tested by changing Async to point to this branch and load files using both local and S3.

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [x] No, and this is why: Changes underlying code to functions, but current functions still have adequate coverage.
- [ ] I need help with writing tests
