### PR TITLE
feat: add new lookup-rule for  entity numbers

### DIFF
--- a/digital_land/phase/lookup.py
+++ b/digital_land/phase/lookup.py
@@ -33,6 +33,7 @@ class LookupPhase(Phase):
         issue_log=None,
         operational_issue_log=None,
         entity_range=[],
+        lookup_rules=None,
     ):
         self.lookups = lookups
         self.redirect_lookups = redirect_lookups
@@ -40,6 +41,7 @@ class LookupPhase(Phase):
         self.operational_issues = operational_issue_log
         self.reverse_lookups = self.build_reverse_lookups()
         self.entity_range = entity_range
+        self.lookup_rules = lookup_rules or []
 
     def build_reverse_lookups(self):
         reverse_lookups = {}
@@ -51,6 +53,27 @@ class LookupPhase(Phase):
 
     def lookup(self, **kwargs):
         return self.lookups.get(key(**kwargs), "")
+
+    def lookup_rule(self, prefix="", organisation="", reference=""):
+        try:
+            ref_int = int(reference)
+        except (ValueError, TypeError):
+            return ""
+
+        prefix_norm = normalise(prefix)
+        org_norm = normalise(organisation)
+
+        for rule in self.lookup_rules:
+            if normalise(rule["prefix"]) != prefix_norm:
+                continue
+            rule_org = normalise(rule.get("organisation", ""))
+            if rule_org and rule_org != org_norm:
+                continue
+            candidate = ref_int + rule["offset"]
+            if rule["entity-minimum"] <= candidate <= rule["entity-maximum"]:
+                return str(candidate)
+
+        return ""
 
     def check_associated_organisation(self, entity):
         if entity in self.reverse_lookups:
@@ -85,6 +108,11 @@ class LookupPhase(Phase):
                 reference=reference,
             )
             or self.lookup(prefix=prefix, reference=reference)
+            or self.lookup_rule(
+                prefix=prefix,
+                organisation=organisation,
+                reference=reference,
+            )
         )
 
         if entity and self.entity_range:
@@ -178,8 +206,11 @@ class FactLookupPhase(LookupPhase):
         issue_log=None,
         odp_collections=None,
         package_prefixes=None,
+        lookup_rules=None,
     ):
-        super().__init__(lookups, redirect_lookups, issue_log)
+        super().__init__(
+            lookups, redirect_lookups, issue_log, lookup_rules=lookup_rules
+        )
         self.entity_field = "reference-entity"
         self.odp_collections = odp_collections
         self.package_prefixes = package_prefixes or {}
@@ -231,6 +262,13 @@ class FactLookupPhase(LookupPhase):
                         prefix=package_prefix, reference=reference
                     )
                     find_entity = self.check_associated_organisation(find_entity)
+
+            if not find_entity:
+                find_entity = self.lookup_rule(
+                    prefix=prefix,
+                    organisation=organisation,
+                    reference=reference,
+                )
 
             if not find_entity or (
                 str(find_entity) in self.redirect_lookups

--- a/digital_land/pipeline/main.py
+++ b/digital_land/pipeline/main.py
@@ -109,6 +109,7 @@ class Pipeline:
         self.concat = {}
         self.migrate = {}
         self.lookup = {}
+        self.lookup_rule = {}
         self.redirect_lookup = {}
 
         self.specification = specification
@@ -124,6 +125,7 @@ class Pipeline:
         self.load_combine_fields()
         self.load_migrate()
         self.load_lookup()
+        self.load_lookup_rule()
         self.load_redirect_lookup()
         self.load_filter()
 
@@ -292,6 +294,56 @@ class Pipeline:
                 )
             ] = row["entity"]
 
+    def load_lookup_rule(self):
+        # optional: collections without a lookup-rule.csv simply have no rules
+        rows = list(self.file_reader("lookup-rule.csv"))
+        if not rows:
+            return
+
+        # validate columns against the schema; "pipeline" is an accepted
+        # legacy alias for the prefix/dataset column
+        allowed_fields = set(Schema("lookup-rule").fieldnames) | {"pipeline"}
+        observed_fields = set().union(*(row.keys() for row in rows))
+        unexpected = observed_fields - allowed_fields
+        if unexpected:
+            raise RuntimeError(
+                "unexpected columns in lookup-rule.csv: "
+                f"{', '.join(sorted(unexpected))}"
+            )
+
+        rule_count = 0
+        for row in rows:
+            prefix = (
+                row.get("prefix", "")
+                or row.get("dataset", "")
+                or row.get("pipeline", "")
+            )
+            organisation = row.get("organisation", "").replace(
+                "local-authority-eng", "local-authority"
+            )
+            resource = row.get("resource", "")
+
+            if (
+                row.get("offset", "")
+                and row.get("entity-minimum", "")
+                and row.get("entity-maximum", "")
+            ):
+                rule = {
+                    "prefix": prefix,
+                    "organisation": organisation,
+                    "offset": int(row["offset"]),
+                    "entity-minimum": int(row["entity-minimum"]),
+                    "entity-maximum": int(row["entity-maximum"]),
+                }
+                self.lookup_rule.setdefault(resource, []).append(rule)
+                rule_count += 1
+
+        if rule_count == 0:
+            logging.warning(
+                "lookup-rule.csv was found but produced no valid rules; "
+                "check the offset, entity-minimum and entity-maximum columns"
+            )
+
     def load_redirect_lookup(self):
         for row in self.file_reader("old-entity.csv"):
             old_entity = row.get("old-entity", "")
@@ -422,6 +474,12 @@ class Pipeline:
         if resource:
             d.update(self.lookup.get(resource, {}))
         return d
+
+    def lookup_rules(self, resource=None):
+        rules = list(self.lookup_rule.get("", []))
+        if resource:
+            rules.extend(self.lookup_rule.get(resource, []))
+        return rules
 
     def redirect_lookups(self):
         return self.redirect_lookup
@@ -577,6 +635,8 @@ class Pipeline:
         concats = self.concatenations(resource, endpoints=endpoints)
         patches = self.patches(resource=resource, endpoints=endpoints)
         lookups = self.lookups(resource=resource)
+        lookup_rules = self.lookup_rules(resource=resource)
+
         default_fields = self.default_fields(resource=resource, endpoints=endpoints)
         default_values = self.default_values(endpoints=endpoints)
         combine_fields = self.combine_fields(endpoints=endpoints)
@@ -652,6 +712,7 @@ class Pipeline:
                         issue_log=self.issue_log,
                         operational_issue_log=self.operational_issue_log,
                         entity_range=[entity_range_min, entity_range_max],
+                        lookup_rules=lookup_rules,
                     ),
                 ]
             )
@@ -691,6 +752,7 @@ class Pipeline:
                     issue_log=self.issue_log,
                     odp_collections=self.specification.get_odp_collections(),
                     package_prefixes=self.specification.get_package_prefixes(),
+                    lookup_rules=lookup_rules,
                 ),
                 FactPrunePhase(),
                 SavePhase(

--- a/digital_land/schema.py
+++ b/digital_land/schema.py
@@ -81,6 +81,21 @@ schemas = {
             "end-date",
         ],
     },
+    "lookup-rule": {
+        "key": "lookup-rule",
+        "fields": [
+            "prefix",
+            "dataset",
+            "organisation",
+            "resource",
+            "offset",
+            "entity-minimum",
+            "entity-maximum",
+            "entry-date",
+            "start-date",
+            "end-date",
+        ],
+    },
     "operational-issue": {
         "fields": [
             "dataset",

--- a/tests/unit/phase/test_lookup.py
+++ b/tests/unit/phase/test_lookup.py
@@ -147,6 +147,100 @@ class TestLookupPhase:
 
         assert output[0]["row"]["entity"] == "10"
 
+    def test_lookup_rule_valid_match(self):
+        lookup_rules = [
+            {
+                "prefix": "dataset",
+                "organisation": "",
+                "offset": 1000,
+                "entity-minimum": 1000,
+                "entity-maximum": 4000,
+            }
+        ]
+        phase = LookupPhase(lookup_rules=lookup_rules)
+        assert phase.lookup_rule(prefix="dataset", reference="100") == "1100"
+
+    def test_lookup_rule_out_of_range(self):
+        lookup_rules = [
+            {
+                "prefix": "dataset",
+                "organisation": "",
+                "offset": 1000,
+                "entity-minimum": 2000,
+                "entity-maximum": 4000,
+            }
+        ]
+        phase = LookupPhase(lookup_rules=lookup_rules)
+        assert phase.lookup_rule(prefix="dataset", reference="100") == ""
+
+    def test_lookup_rule_non_integer_reference(self):
+        lookup_rules = [
+            {
+                "prefix": "dataset",
+                "organisation": "",
+                "offset": 1000,
+                "entity-minimum": 1000,
+                "entity-maximum": 4000,
+            }
+        ]
+        phase = LookupPhase(lookup_rules=lookup_rules)
+        assert phase.lookup_rule(prefix="dataset", reference="abc") == ""
+
+    def test_lookup_rule_no_matching_prefix(self):
+        lookup_rules = [
+            {
+                "prefix": "other-dataset",
+                "organisation": "",
+                "offset": 1000,
+                "entity-minimum": 1000,
+                "entity-maximum": 4000,
+            }
+        ]
+        phase = LookupPhase(lookup_rules=lookup_rules)
+        assert phase.lookup_rule(prefix="dataset", reference="100") == ""
+
+    def test_lookup_rule_with_organisation(self):
+        lookup_rules = [
+            {
+                "prefix": "dataset",
+                "organisation": "local-authority:ABC",
+                "offset": 1000,
+                "entity-minimum": 1000,
+                "entity-maximum": 4000,
+            }
+        ]
+        phase = LookupPhase(lookup_rules=lookup_rules)
+        assert (
+            phase.lookup_rule(
+                prefix="dataset", organisation="local-authority:ABC", reference="100"
+            )
+            == "1100"
+        )
+        assert (
+            phase.lookup_rule(
+                prefix="dataset", organisation="local-authority:XYZ", reference="100"
+            )
+            == ""
+        )
+
+    def test_lookup_rule_fallback_in_get_entity(self):
+        lookup_rules = [
+            {
+                "prefix": "dataset",
+                "organisation": "",
+                "offset": 1000,
+                "entity-minimum": 1000,
+                "entity-maximum": 4000,
+            }
+        ]
+        phase = LookupPhase(lookup_rules=lookup_rules)
+        phase.entity_field = "entity"
+        block = {
+            "row": {"prefix": "dataset", "reference": "100", "organisation": ""},
+            "entry-number": 1,
+        }
+        assert phase.get_entity(block) == "1100"
+
 
 class TestPrintLookupPhase:
     def test_process_does_not_produce_new_lookup(self, get_input_stream, get_lookup):

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env -S py.test -svv
 import io
+import logging
 import pytest
 from digital_land.pipeline import EntityNumGen, Pipeline
 from digital_land.pipeline import Lookups
@@ -366,6 +367,149 @@ class TestPipeLine:
 
         if new_lookup[0]["entity"] is None:
             assert True
+
+    def test_load_lookup_rule_with_all_fields(self, mocker):
+        def mock_file_reader(self, filepath):
+            if filepath == "lookup-rule.csv":
+                return [
+                    {
+                        "prefix": "listed-building",
+                        "organisation": "",
+                        "offset": "1000000",
+                        "entity-minimum": "1000000",
+                        "entity-maximum": "2000000",
+                        "resource": "",
+                    }
+                ]
+            return []
+
+        mocker.patch("digital_land.pipeline.Pipeline.file_reader", mock_file_reader)
+        p = Pipeline("anything", "stuff")
+        rules = p.lookup_rules()
+        assert len(rules) == 1
+        assert rules[0]["offset"] == 1000000
+        assert rules[0]["entity-minimum"] == 1000000
+        assert rules[0]["entity-maximum"] == 2000000
+        assert rules[0]["prefix"] == "listed-building"
+
+    def test_load_lookup_rule_missing_entity_minimum(self, mocker):
+        def mock_file_reader(self, filepath):
+            if filepath == "lookup-rule.csv":
+                return [
+                    {
+                        "prefix": "listed-building",
+                        "organisation": "",
+                        "offset": "1000000",
+                        "entity-minimum": "",
+                        "entity-maximum": "2000000",
+                        "resource": "",
+                    }
+                ]
+            return []
+
+        mocker.patch("digital_land.pipeline.Pipeline.file_reader", mock_file_reader)
+        p = Pipeline("anything", "stuff")
+        assert len(p.lookup_rules()) == 0
+
+    def test_load_lookup_rule_missing_entity_maximum(self, mocker):
+        def mock_file_reader(self, filepath):
+            if filepath == "lookup-rule.csv":
+                return [
+                    {
+                        "prefix": "listed-building",
+                        "organisation": "",
+                        "offset": "1000000",
+                        "entity-minimum": "1000000",
+                        "entity-maximum": "",
+                        "resource": "",
+                    }
+                ]
+            return []
+
+        mocker.patch("digital_land.pipeline.Pipeline.file_reader", mock_file_reader)
+        p = Pipeline("anything", "stuff")
+        assert len(p.lookup_rules()) == 0
+
+    def test_load_lookup_rule_unexpected_column(self, mocker):
+        def mock_file_reader(self, filepath):
+            if filepath == "lookup-rule.csv":
+                return [
+                    {
+                        "prefix": "listed-building",
+                        "offset": "1000000",
+                        "entity-min": "1000000",  # typo for entity-minimum
+                        "entity-maximum": "2000000",
+                        "resource": "",
+                    }
+                ]
+            return []
+
+        mocker.patch("digital_land.pipeline.Pipeline.file_reader", mock_file_reader)
+        with pytest.raises(RuntimeError, match="unexpected columns"):
+            Pipeline("anything", "stuff")
+
+    def test_load_lookup_rule_warns_when_no_valid_rules(self, mocker, caplog):
+        def mock_file_reader(self, filepath):
+            if filepath == "lookup-rule.csv":
+                return [
+                    {
+                        "prefix": "listed-building",
+                        "organisation": "",
+                        "offset": "1000000",
+                        "entity-minimum": "",  # missing -> no rule built
+                        "entity-maximum": "2000000",
+                        "resource": "",
+                    }
+                ]
+            return []
+
+        mocker.patch("digital_land.pipeline.Pipeline.file_reader", mock_file_reader)
+        with caplog.at_level(logging.WARNING):
+            p = Pipeline("anything", "stuff")
+
+        assert len(p.lookup_rules()) == 0
+        assert any("lookup-rule.csv" in r.message for r in caplog.records)
+
+    def test_lookup_rules_resource_scoping(self, mocker):
+        def mock_file_reader(self, filepath):
+            if filepath == "lookup-rule.csv":
+                return [
+                    {
+                        "prefix": "listed-building",
+                        "organisation": "",
+                        "offset": "1000000",
+                        "entity-minimum": "1000000",
+                        "entity-maximum": "2000000",
+                        "resource": "",  # global rule
+                    },
+                    {
+                        "prefix": "listed-building",
+                        "organisation": "",
+                        "offset": "5000000",
+                        "entity-minimum": "5000000",
+                        "entity-maximum": "6000000",
+                        "resource": "res1",  # resource-specific rule
+                    },
+                ]
+            return []
+
+        mocker.patch("digital_land.pipeline.Pipeline.file_reader", mock_file_reader)
+        p = Pipeline("anything", "stuff")
+
+        # no resource -> only the global rule
+        global_rules = p.lookup_rules()
+        assert len(global_rules) == 1
+        assert global_rules[0]["offset"] == 1000000
+
+        # matching resource -> global rule plus the resource-specific one
+        scoped_rules = p.lookup_rules(resource="res1")
+        assert len(scoped_rules) == 2
+        assert {r["offset"] for r in scoped_rules} == {1000000, 5000000}
+
+        # unrelated resource -> only the global rule
+        other_rules = p.lookup_rules(resource="other")
+        assert len(other_rules) == 1
+        assert other_rules[0]["offset"] == 1000000
 
     @pytest.fixture
     def pipeline(self, mocker):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds a **lookup rule** mechanism for assigning entity numbers. Instead of an exact `lookup.csv` row per reference, a collection can provide an optional `lookup-rule.csv` defining a rule: apply an `offset` to an incoming integer reference, and if the result falls within a dataset's entity range (`entity-minimum`/`entity-maximum`, inclusive), assign that number as the entity.

## Why

Some datasets - e.g. title-boundaries - would require managing an unmanageable number of individual entity records if we relied on exact reference-to-entity lookups. A range-based rule lets a whole dataset's entities be assigned from a single, compact rule instead of millions of lookup rows, which is the prerequisite for adding title boundaries.


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com/digital-land/config/issues/2748)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

True testing for this will take place once I begin running title-boundary in DEV, but until then this is going to lie dormant for a few days until that is ready.

## Testing this PR is safe

This change is **inert for existing pipelines** — it cannot alter the output of any current collection, because none of them have `lookup_rule.csv`s in the config repo, in fact currently no collections have lookup_rule.csv in the config repo and this code change will only do anything when I add one to title-boundry.  

Ran a pipeline locally with the changes and it all ran fine.

Plus all the existing tests pass.


## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
