### PR TITLE
feat: handle multiple organisation per resource

### DIFF
--- a/digital_land/check.py
+++ b/digital_land/check.py
@@ -1,6 +1,7 @@
 import duckdb
 import logging
 import dask.dataframe as dd
+import pandas as pd
 
 
 # TODO This might need to move into expectations as it is a form of data checking
@@ -22,10 +23,11 @@ def duplicate_reference_check(issues=None, csv_path=None):
             "field",
             "value",
             "entry_date",
+            "entity",
             COUNT(*) AS count,
             STRING_AGG("entry_number"::TEXT, ',') AS entry_numbers
         FROM filtered_table
-        GROUP BY "field", "value", "entry_date"
+        GROUP BY "field", "value", "entry_date", "entity"
         HAVING COUNT(*) > 1;
         """
 
@@ -34,11 +36,14 @@ def duplicate_reference_check(issues=None, csv_path=None):
         if len(count_table) >= 1:
             duplicate_references = count_table[count_table["count"] > 1]
             for idx, row in duplicate_references.iterrows():
+                entity = row["entity"]
+                entity = int(entity) if pd.notna(entity) else None
                 for entry_number in row["entry_numbers"].split(","):
                     issues.log_issue(
                         "reference",
                         "reference values are not unique",
                         row["value"],
+                        entity=entity,
                         entry_number=int(entry_number),
                         line_number=int(entry_number)
                         + 1,  # TODO Check this makes sense in all cases

--- a/digital_land/phase/lookup.py
+++ b/digital_land/phase/lookup.py
@@ -84,14 +84,14 @@ class LookupPhase(Phase):
                     return ""
         return entity
 
-    def get_entity(self, block):
+    def get_entity(self, block, organisation=None):
         row = block["row"]
         prefix = row.get("prefix", "")
         reference = row.get("reference", "")
         # Eventually won't be needed but leave in for now
-        organisation = row.get("organisation", "").replace(
-            "local-authority-eng", "local-authority"
-        )
+        if organisation is None:
+            organisation = row.get("organisation", "")
+        organisation = organisation.replace("local-authority-eng", "local-authority")
         entry_number = block["entry-number"]
 
         entity = (
@@ -143,6 +143,31 @@ class LookupPhase(Phase):
                     return ""
         return entity
 
+    def _log_unknown_entity(self, reference, curie, line_number):
+        if not self.issues:
+            return
+        if not reference:
+            self.issues.log_issue(
+                "entity",
+                "unknown entity - missing reference",
+                curie,
+                line_number=line_number,
+            )
+        else:
+            self.issues.log_issue(
+                "entity",
+                "unknown entity",
+                curie,
+                line_number=line_number,
+            )
+            if self.operational_issues:
+                self.operational_issues.log_issue(
+                    "entity",
+                    "unknown entity",
+                    curie,
+                    line_number=line_number,
+                )
+
     def process(self, stream):
         for block in stream:
             row = block["row"]
@@ -189,13 +214,84 @@ class LookupPhase(Phase):
 class EntityLookupPhase(LookupPhase):
     entity_field = "entity"
 
+    def __init__(
+        self,
+        lookups={},
+        redirect_lookups={},
+        issue_log=None,
+        operational_issue_log=None,
+        entity_range=[],
+        lookup_rules=None,
+        organisations=None,
+    ):
+        super().__init__(
+            lookups=lookups,
+            redirect_lookups=redirect_lookups,
+            issue_log=issue_log,
+            operational_issue_log=operational_issue_log,
+            entity_range=entity_range,
+            lookup_rules=lookup_rules,
+        )
+        self.organisations = organisations or []
+
     def process(self, stream):
+        # A resource may be associated with more than one organisation (e.g. a
+        # joint local plan shared by two authorities). In that case the entity
+        # is resolved once per organisation and a row is emitted per distinct
+        # entity. With a single organisation (or none) each row resolves to at
+        # most one entity.
+        if len(self.organisations) > 1:
+            yield from self._process_multi_org(stream)
+            return
+
         for block in super().process(stream):
             if self.issues:
                 self.issues.record_entity_map(
                     block["entry-number"], block["row"]["entity"]
                 )
             yield block
+
+    def _process_multi_org(self, stream):
+        for block in stream:
+            row = block["row"]
+            prefix = row.get("prefix", "")
+            reference = row.get("reference", "")
+            curie = f"{prefix}:{reference}"
+            line_number = block["line-number"]
+
+            # Nothing to look up if there is no prefix, or an entity has
+            # already been assigned upstream.
+            if not prefix or row.get(self.entity_field, ""):
+                if self.issues:
+                    self.issues.record_entity_map(
+                        block["entry-number"], row.get(self.entity_field, "")
+                    )
+                yield block
+                continue
+
+            emitted_entities = set()
+            for organisation in self.organisations:
+                entity = self.get_entity(block, organisation=organisation)
+
+                if not entity:
+                    # no entity for this organisation: log an unknown-entity
+                    # issue and emit no row for it
+                    self._log_unknown_entity(reference, curie, line_number)
+                    continue
+
+                entity = self.redirect_entity(entity)
+                if not entity or entity in emitted_entities:
+                    continue
+                emitted_entities.add(entity)
+
+                new_block = dict(block)
+                new_block["row"] = dict(row)
+                new_block["row"][self.entity_field] = entity
+                new_block["row"]["organisation"] = organisation
+                new_block["organisation"] = organisation
+                if self.issues:
+                    self.issues.record_entity_map(block["entry-number"], entity)
+                yield new_block
 
 
 class FactLookupPhase(LookupPhase):

--- a/digital_land/phase/lookup.py
+++ b/digital_land/phase/lookup.py
@@ -297,9 +297,9 @@ class EntityLookupPhase(LookupPhase):
                 yield block
                 continue
 
-            yield from self._fan_out(block)
+            yield from self._get_provider_entity_numbers(block)
 
-    def _fan_out(self, block):
+    def _get_provider_entity_numbers(self, block):
         """Resolve the entity for a row that has no organisation of its own.
 
         The reference is looked up once per provider, and distinct entities

--- a/digital_land/phase/lookup.py
+++ b/digital_land/phase/lookup.py
@@ -305,13 +305,21 @@ class EntityLookupPhase(LookupPhase):
         The reference is looked up once per provider, and distinct entities
         produce distinct rows, each stamped with the organisation it was looked
         up with; if two providers resolve to the same entity only one row is
-        emitted. A provider that resolves nothing raises an unknown-entity issue
-        and produces no row, so an entry may yield fewer rows than there are
-        providers — including none.
+        emitted. A provider that resolves nothing simply produces no row, so an
+        entry may yield fewer rows than there are providers — including none.
 
         Some collections do map a source column to the organisation (e.g.
         conservation-area's `borough`), and that organisation need not be one of
         the providers — so when the row knows, it is resolved against that alone.
+
+        An unknown-entity issue is raised only when NO organisation resolves an
+        entity. A resource shared by several organisations often holds one
+        organisation's rows alongside another's, so a reference missing for the
+        organisation that does not own it is normal, not a fault. Issues also
+        carry no organisation of their own and are fanned out to every
+        organisation on the resource when they become tasks, so a per-organisation
+        miss would tell both authorities their records were missing while the
+        entity sat correctly assigned.
 
         The organisation is set on the block as well as the row because
         FactLookupPhase reads it after the pivot, once row-level fields are gone.
@@ -336,9 +344,7 @@ class EntityLookupPhase(LookupPhase):
             entity = self.get_entity(block, organisation=organisation)
 
             if not entity:
-                # no entity for this organisation: log an unknown-entity
-                # issue and emit no row for it
-                self._log_unknown_entity(reference, curie, line_number)
+                # this organisation does not own the reference: no row for it
                 continue
 
             entity = self.redirect_entity(entity)
@@ -354,6 +360,11 @@ class EntityLookupPhase(LookupPhase):
             if self.issues:
                 self.issues.record_entity_map(block["entry-number"], entity)
             yield new_block
+
+        # no organisation resolved an entity: raise a single unknown-entity
+        # issue, as the inherited single-organisation path does
+        if not emitted_entities:
+            self._log_unknown_entity(reference, curie, line_number)
 
 
 class FactLookupPhase(LookupPhase):

--- a/digital_land/phase/lookup.py
+++ b/digital_land/phase/lookup.py
@@ -300,25 +300,39 @@ class EntityLookupPhase(LookupPhase):
             yield from self._fan_out(block)
 
     def _fan_out(self, block):
-        """Resolve the entity once per provider, yielding a row per entity.
+        """Resolve the entity for a row that has no organisation of its own.
 
-        Distinct entities produce distinct rows, each stamped with the
-        organisation it was looked up with; if two providers resolve to the same
-        entity only one row is emitted. A provider that resolves nothing raises
-        an unknown-entity issue and produces no row, so an entry may yield fewer
-        rows than there are providers — including none.
+        The reference is looked up once per provider, and distinct entities
+        produce distinct rows, each stamped with the organisation it was looked
+        up with; if two providers resolve to the same entity only one row is
+        emitted. A provider that resolves nothing raises an unknown-entity issue
+        and produces no row, so an entry may yield fewer rows than there are
+        providers — including none.
+
+        Some collections do map a source column to the organisation (e.g.
+        conservation-area's `borough`), and that organisation need not be one of
+        the providers — so when the row knows, it is resolved against that alone.
 
         The organisation is set on the block as well as the row because
         FactLookupPhase reads it after the pivot, once row-level fields are gone.
         """
+
         row = block["row"]
         prefix = row.get("prefix", "")
         reference = row.get("reference", "")
         curie = f"{prefix}:{reference}"
         line_number = block["line-number"]
 
+        # Some collections map a source column to the organisation (e.g.
+        # conservation-area's `borough`), so a row may already say which
+        # authority it belongs to — and it need not be one of the providers.
+        # Trust the row when it knows; only try every provider when it doesn't.
+        organisations = (
+            [row["organisation"]] if row.get("organisation", "") else self.providers
+        )
+
         emitted_entities = set()
-        for organisation in self.providers:
+        for organisation in organisations:
             entity = self.get_entity(block, organisation=organisation)
 
             if not entity:

--- a/digital_land/phase/lookup.py
+++ b/digital_land/phase/lookup.py
@@ -91,7 +91,9 @@ class LookupPhase(Phase):
             organisation (str, optional): Organisation to resolve the entity against.
                 Defaults to None, meaning use the organisation already on the row.
                 EntityLookupPhase passes this explicitly when fanning out a
-                multi-organisation resource, where the row's organisation is blank.
+                multi-organisation resource, where the row's organisation is blank
+                because the resource-level default is only applied when a resource
+                has exactly one organisation.
 
         Returns:
             str: The entity number, or "" if nothing matched.
@@ -249,11 +251,11 @@ class EntityLookupPhase(LookupPhase):
         operational_issue_log=None,
         entity_range=[],
         lookup_rules=None,
-        organisations=None,
+        providers=None,
     ):
         """
         Args:
-            organisations (list, optional): Organisation codes associated with the
+            providers (list, optional): Organisation codes that provided the
                 resource. More than one means the resource is shared, and the entity
                 is resolved once per organisation. Defaults to None (no fan-out).
         """
@@ -266,7 +268,7 @@ class EntityLookupPhase(LookupPhase):
             entity_range=entity_range,
             lookup_rules=lookup_rules,
         )
-        self.organisations = organisations or []
+        self.providers = providers or []
 
     def process(self, stream):
         # A resource may be associated with more than one organisation (e.g. a
@@ -274,7 +276,7 @@ class EntityLookupPhase(LookupPhase):
         # is resolved once per organisation and a row is emitted per distinct
         # entity. With a single organisation (or none) each row resolves to at
         # most one entity.
-        if len(self.organisations) > 1:
+        if len(self.providers) > 1:
             yield from self._process_multi_org(stream)
             return
 
@@ -317,7 +319,7 @@ class EntityLookupPhase(LookupPhase):
                 continue
 
             emitted_entities = set()
-            for organisation in self.organisations:
+            for organisation in self.providers:
                 entity = self.get_entity(block, organisation=organisation)
 
                 if not entity:

--- a/digital_land/phase/lookup.py
+++ b/digital_land/phase/lookup.py
@@ -85,6 +85,17 @@ class LookupPhase(Phase):
         return entity
 
     def get_entity(self, block, organisation=None):
+        """Look up the entity for a block's prefix and reference.
+
+        Args:
+            organisation (str, optional): Organisation to resolve the entity against.
+                Defaults to None, meaning use the organisation already on the row.
+                EntityLookupPhase passes this explicitly when fanning out a
+                multi-organisation resource, where the row's organisation is blank.
+
+        Returns:
+            str: The entity number, or "" if nothing matched.
+        """
         row = block["row"]
         prefix = row.get("prefix", "")
         reference = row.get("reference", "")
@@ -144,6 +155,7 @@ class LookupPhase(Phase):
         return entity
 
     def _log_unknown_entity(self, reference, curie, line_number):
+        """Raise an unknown-entity issue, distinguishing a missing reference."""
         if not self.issues:
             return
         if not reference:
@@ -212,6 +224,21 @@ class LookupPhase(Phase):
 
 
 class EntityLookupPhase(LookupPhase):
+    """
+    lookup the entity for an entry's reference
+
+    A resource is identified by the hash of its contents, so when several
+    organisations publish identical data the collection merges them into one
+    resource carrying every organisation's code (e.g. a joint local plan, or a
+    brownfield register published by two authorities). Those rows arrive here
+    with a blank organisation, because the resource-level default is only
+    applied when the resource has exactly one organisation.
+
+    When given more than one organisation this phase resolves the entity once
+    per organisation and emits a row per distinct entity. With one organisation
+    (or none) it behaves exactly as it always has.
+    """
+
     entity_field = "entity"
 
     def __init__(
@@ -224,6 +251,13 @@ class EntityLookupPhase(LookupPhase):
         lookup_rules=None,
         organisations=None,
     ):
+        """
+        Args:
+            organisations (list, optional): Organisation codes associated with the
+                resource. More than one means the resource is shared, and the entity
+                is resolved once per organisation. Defaults to None (no fan-out).
+        """
+
         super().__init__(
             lookups=lookups,
             redirect_lookups=redirect_lookups,
@@ -252,6 +286,19 @@ class EntityLookupPhase(LookupPhase):
             yield block
 
     def _process_multi_org(self, stream):
+        """Resolve the entity once per organisation and fan out the row.
+
+        For each entry the reference is looked up against every organisation on
+        the resource. Distinct entities produce distinct rows, each stamped with
+        the organisation it was looked up with; if two organisations resolve to
+        the same entity only one row is emitted. An organisation that resolves
+        nothing raises an unknown-entity issue and produces no row, so an entry
+        may yield fewer rows than there are organisations — including none.
+
+        The organisation is set on the block as well as the row because
+        FactLookupPhase reads it after the pivot, once row-level fields are gone.
+        """
+
         for block in stream:
             row = block["row"]
             prefix = row.get("prefix", "")

--- a/digital_land/phase/lookup.py
+++ b/digital_land/phase/lookup.py
@@ -271,46 +271,25 @@ class EntityLookupPhase(LookupPhase):
         self.providers = providers or []
 
     def process(self, stream):
-        # A resource may be associated with more than one organisation (e.g. a
-        # joint local plan shared by two authorities). In that case the entity
-        # is resolved once per organisation and a row is emitted per distinct
-        # entity. With a single organisation (or none) each row resolves to at
-        # most one entity.
-        if len(self.providers) > 1:
-            yield from self._process_multi_org(stream)
+        # With a single provider (or none) the row already carries the
+        # organisation, so the inherited behaviour is used unchanged. Only a
+        # resource shared by several organisations (e.g. a joint local plan)
+        # needs the entity resolving once per organisation.
+        if len(self.providers) <= 1:
+            for block in super().process(stream):
+                if self.issues:
+                    self.issues.record_entity_map(
+                        block["entry-number"], block["row"]["entity"]
+                    )
+                yield block
             return
-
-        for block in super().process(stream):
-            if self.issues:
-                self.issues.record_entity_map(
-                    block["entry-number"], block["row"]["entity"]
-                )
-            yield block
-
-    def _process_multi_org(self, stream):
-        """Resolve the entity once per organisation and fan out the row.
-
-        For each entry the reference is looked up against every organisation on
-        the resource. Distinct entities produce distinct rows, each stamped with
-        the organisation it was looked up with; if two organisations resolve to
-        the same entity only one row is emitted. An organisation that resolves
-        nothing raises an unknown-entity issue and produces no row, so an entry
-        may yield fewer rows than there are organisations — including none.
-
-        The organisation is set on the block as well as the row because
-        FactLookupPhase reads it after the pivot, once row-level fields are gone.
-        """
 
         for block in stream:
             row = block["row"]
-            prefix = row.get("prefix", "")
-            reference = row.get("reference", "")
-            curie = f"{prefix}:{reference}"
-            line_number = block["line-number"]
 
             # Nothing to look up if there is no prefix, or an entity has
             # already been assigned upstream.
-            if not prefix or row.get(self.entity_field, ""):
+            if not row.get("prefix", "") or row.get(self.entity_field, ""):
                 if self.issues:
                     self.issues.record_entity_map(
                         block["entry-number"], row.get(self.entity_field, "")
@@ -318,29 +297,49 @@ class EntityLookupPhase(LookupPhase):
                 yield block
                 continue
 
-            emitted_entities = set()
-            for organisation in self.providers:
-                entity = self.get_entity(block, organisation=organisation)
+            yield from self._fan_out(block)
 
-                if not entity:
-                    # no entity for this organisation: log an unknown-entity
-                    # issue and emit no row for it
-                    self._log_unknown_entity(reference, curie, line_number)
-                    continue
+    def _fan_out(self, block):
+        """Resolve the entity once per provider, yielding a row per entity.
 
-                entity = self.redirect_entity(entity)
-                if not entity or entity in emitted_entities:
-                    continue
-                emitted_entities.add(entity)
+        Distinct entities produce distinct rows, each stamped with the
+        organisation it was looked up with; if two providers resolve to the same
+        entity only one row is emitted. A provider that resolves nothing raises
+        an unknown-entity issue and produces no row, so an entry may yield fewer
+        rows than there are providers — including none.
 
-                new_block = dict(block)
-                new_block["row"] = dict(row)
-                new_block["row"][self.entity_field] = entity
-                new_block["row"]["organisation"] = organisation
-                new_block["organisation"] = organisation
-                if self.issues:
-                    self.issues.record_entity_map(block["entry-number"], entity)
-                yield new_block
+        The organisation is set on the block as well as the row because
+        FactLookupPhase reads it after the pivot, once row-level fields are gone.
+        """
+        row = block["row"]
+        prefix = row.get("prefix", "")
+        reference = row.get("reference", "")
+        curie = f"{prefix}:{reference}"
+        line_number = block["line-number"]
+
+        emitted_entities = set()
+        for organisation in self.providers:
+            entity = self.get_entity(block, organisation=organisation)
+
+            if not entity:
+                # no entity for this organisation: log an unknown-entity
+                # issue and emit no row for it
+                self._log_unknown_entity(reference, curie, line_number)
+                continue
+
+            entity = self.redirect_entity(entity)
+            if not entity or entity in emitted_entities:
+                continue
+            emitted_entities.add(entity)
+
+            new_block = dict(block)
+            new_block["row"] = dict(row)
+            new_block["row"][self.entity_field] = entity
+            new_block["row"]["organisation"] = organisation
+            new_block["organisation"] = organisation
+            if self.issues:
+                self.issues.record_entity_map(block["entry-number"], entity)
+            yield new_block
 
 
 class FactLookupPhase(LookupPhase):

--- a/digital_land/pipeline/main.py
+++ b/digital_land/pipeline/main.py
@@ -713,6 +713,7 @@ class Pipeline:
                         operational_issue_log=self.operational_issue_log,
                         entity_range=[entity_range_min, entity_range_max],
                         lookup_rules=lookup_rules,
+                        organisations=organisations,
                     ),
                 ]
             )

--- a/digital_land/pipeline/main.py
+++ b/digital_land/pipeline/main.py
@@ -605,7 +605,9 @@ class Pipeline:
             resource (str): Resource file identifier (hash), TBD can be removed.
             valid_category_values (dict): Dictionary of valid category values per field from the API/specification.
             endpoints (list, optional): List of endpoint hashes/identifiers for this resource. Defaults to None.
-            organisations (list, optional): List of organisation codes/identifiers associated with the resource. Defaults to None, Note if one passed, org will become default value
+            organisations (list, optional): List of organisation codes/identifiers associated with the resource. Defaults to None.
+                If one is passed it becomes the default organisation for every row; if more than one, no default is applied and
+                EntityLookupPhase resolves the entity once per organisation.
             entry_date (str, optional): Default entry-date value to apply to all records. Defaults to "".
             converted_path (str, optional): Path to save converted (pre-normalised) resource. Defaults to None.
             harmonised_output_path (str, optional): Path to save the harmonised/intermediate output. Defaults to None.

--- a/digital_land/pipeline/main.py
+++ b/digital_land/pipeline/main.py
@@ -715,7 +715,7 @@ class Pipeline:
                         operational_issue_log=self.operational_issue_log,
                         entity_range=[entity_range_min, entity_range_max],
                         lookup_rules=lookup_rules,
-                        organisations=organisations,
+                        providers=organisations,
                     ),
                 ]
             )

--- a/tests/unit/phase/test_lookup.py
+++ b/tests/unit/phase/test_lookup.py
@@ -434,6 +434,42 @@ class TestEntityLookupPhase:
             "unknown entity",
         ]
 
+    def test_multi_org_row_with_own_organisation_is_not_fanned_out(self):
+        # Some collections map a source column to the organisation (e.g.
+        # conservation-area's `borough`), and it need not be one of the
+        # providers. The row knows which authority it belongs to, so it is
+        # resolved against that alone and the providers are never tried.
+        input_stream = [
+            {
+                "row": {
+                    "prefix": "local-plan",
+                    "reference": "owen",
+                    "organisation": "local-authority:XY",
+                },
+                "entry-number": 1,
+                "line-number": 2,
+            }
+        ]
+        lookups = {
+            ",local-plan,owen,local-authorityoe": "101",
+            ",local-plan,owen,local-authoritytb": "102",
+            ",local-plan,owen,local-authorityxy": "103",
+        }
+        issues = IssueLog()
+        phase = EntityLookupPhase(
+            lookups=lookups,
+            issue_log=issues,
+            providers=["local-authority:OE", "local-authority:TB"],
+        )
+        output = [block for block in phase.process(input_stream)]
+
+        # one row for the row's own org, not one per provider
+        assert len(output) == 1
+        assert output[0]["row"]["entity"] == "103"
+        assert output[0]["row"]["organisation"] == "local-authority:XY"
+        # the providers were never looked up, so nothing "missed"
+        assert issues.rows == []
+
     def test_single_org_uses_unchanged_path(self):
         # len(providers) <= 1 must not fan out; org read from the row as before.
         input_stream = [

--- a/tests/unit/phase/test_lookup.py
+++ b/tests/unit/phase/test_lookup.py
@@ -335,7 +335,7 @@ class TestEntityLookupPhase:
         }
         phase = EntityLookupPhase(
             lookups=lookups,
-            organisations=["local-authority:OE", "local-authority:TB"],
+            providers=["local-authority:OE", "local-authority:TB"],
         )
         output = [block for block in phase.process(input_stream)]
 
@@ -370,7 +370,7 @@ class TestEntityLookupPhase:
         }
         phase = EntityLookupPhase(
             lookups=lookups,
-            organisations=["local-authority:OE", "local-authority:TB"],
+            providers=["local-authority:OE", "local-authority:TB"],
         )
         output = [block for block in phase.process(input_stream)]
 
@@ -397,7 +397,7 @@ class TestEntityLookupPhase:
         phase = EntityLookupPhase(
             lookups=lookups,
             issue_log=issues,
-            organisations=["local-authority:OE", "local-authority:TB"],
+            providers=["local-authority:OE", "local-authority:TB"],
         )
         output = [block for block in phase.process(input_stream)]
 
@@ -423,7 +423,7 @@ class TestEntityLookupPhase:
         phase = EntityLookupPhase(
             lookups=lookups,
             issue_log=issues,
-            organisations=["local-authority:OE", "local-authority:TB"],
+            providers=["local-authority:OE", "local-authority:TB"],
         )
         output = [block for block in phase.process(input_stream)]
 
@@ -435,7 +435,7 @@ class TestEntityLookupPhase:
         ]
 
     def test_single_org_uses_unchanged_path(self):
-        # len(organisations) <= 1 must not fan out; org read from the row as before.
+        # len(providers) <= 1 must not fan out; org read from the row as before.
         input_stream = [
             {
                 "row": {
@@ -450,7 +450,7 @@ class TestEntityLookupPhase:
         lookups = {",local-plan,owen,local-authorityoe": "101"}
         phase = EntityLookupPhase(
             lookups=lookups,
-            organisations=["local-authority:OE"],
+            providers=["local-authority:OE"],
         )
         output = [block for block in phase.process(input_stream)]
 

--- a/tests/unit/phase/test_lookup.py
+++ b/tests/unit/phase/test_lookup.py
@@ -315,6 +315,148 @@ class TestEntityLookupPhase:
 
         assert len(output) == 0
 
+    def test_multi_org_fans_out_to_distinct_entities(self):
+        # One joint-plan row, two orgs, two different entities -> two rows out,
+        # each stamped with the org it was looked up with (row + block level).
+        input_stream = [
+            {
+                "row": {
+                    "prefix": "local-plan",
+                    "reference": "owen",
+                    "organisation": "",
+                },
+                "entry-number": 1,
+                "line-number": 2,
+            }
+        ]
+        lookups = {
+            ",local-plan,owen,local-authorityoe": "101",
+            ",local-plan,owen,local-authoritytb": "102",
+        }
+        phase = EntityLookupPhase(
+            lookups=lookups,
+            organisations=["local-authority:OE", "local-authority:TB"],
+        )
+        output = [block for block in phase.process(input_stream)]
+
+        assert len(output) == 2
+        entity_to_org = {b["row"]["entity"]: b["row"]["organisation"] for b in output}
+        assert entity_to_org == {
+            "101": "local-authority:OE",
+            "102": "local-authority:TB",
+        }
+        # org also stamped at block level (FactLookupPhase reads this post-pivot)
+        assert {b["organisation"] for b in output} == {
+            "local-authority:OE",
+            "local-authority:TB",
+        }
+
+    def test_multi_org_same_entity_produces_single_row(self):
+        # Both orgs resolve to the same entity -> one row, no dedupe-after needed.
+        input_stream = [
+            {
+                "row": {
+                    "prefix": "local-plan",
+                    "reference": "owen",
+                    "organisation": "",
+                },
+                "entry-number": 1,
+                "line-number": 2,
+            }
+        ]
+        lookups = {
+            ",local-plan,owen,local-authorityoe": "101",
+            ",local-plan,owen,local-authoritytb": "101",
+        }
+        phase = EntityLookupPhase(
+            lookups=lookups,
+            organisations=["local-authority:OE", "local-authority:TB"],
+        )
+        output = [block for block in phase.process(input_stream)]
+
+        assert len(output) == 1
+        assert output[0]["row"]["entity"] == "101"
+        # first org to resolve the entity wins
+        assert output[0]["row"]["organisation"] == "local-authority:OE"
+
+    def test_multi_org_one_missing_raises_issue_and_emits_found(self):
+        # OE resolves, TB has no lookup -> one row for OE + one unknown-entity issue.
+        input_stream = [
+            {
+                "row": {
+                    "prefix": "local-plan",
+                    "reference": "owen",
+                    "organisation": "",
+                },
+                "entry-number": 1,
+                "line-number": 2,
+            }
+        ]
+        lookups = {",local-plan,owen,local-authorityoe": "101"}
+        issues = IssueLog()
+        phase = EntityLookupPhase(
+            lookups=lookups,
+            issue_log=issues,
+            organisations=["local-authority:OE", "local-authority:TB"],
+        )
+        output = [block for block in phase.process(input_stream)]
+
+        assert len(output) == 1
+        assert output[0]["row"]["entity"] == "101"
+        assert output[0]["row"]["organisation"] == "local-authority:OE"
+        assert [i["issue-type"] for i in issues.rows] == ["unknown entity"]
+
+    def test_multi_org_neither_found_emits_nothing_and_raises_issues(self):
+        input_stream = [
+            {
+                "row": {
+                    "prefix": "local-plan",
+                    "reference": "owen",
+                    "organisation": "",
+                },
+                "entry-number": 1,
+                "line-number": 2,
+            }
+        ]
+        lookups = {}
+        issues = IssueLog()
+        phase = EntityLookupPhase(
+            lookups=lookups,
+            issue_log=issues,
+            organisations=["local-authority:OE", "local-authority:TB"],
+        )
+        output = [block for block in phase.process(input_stream)]
+
+        assert output == []
+        # one unknown-entity issue per organisation that missed
+        assert [i["issue-type"] for i in issues.rows] == [
+            "unknown entity",
+            "unknown entity",
+        ]
+
+    def test_single_org_uses_unchanged_path(self):
+        # len(organisations) <= 1 must not fan out; org read from the row as before.
+        input_stream = [
+            {
+                "row": {
+                    "prefix": "local-plan",
+                    "reference": "owen",
+                    "organisation": "local-authority:OE",
+                },
+                "entry-number": 1,
+                "line-number": 2,
+            }
+        ]
+        lookups = {",local-plan,owen,local-authorityoe": "101"}
+        phase = EntityLookupPhase(
+            lookups=lookups,
+            organisations=["local-authority:OE"],
+        )
+        output = [block for block in phase.process(input_stream)]
+
+        assert len(output) == 1
+        assert output[0]["row"]["entity"] == "101"
+
 
 class TestFactLookupPhase:
     def test_missing_associated_entity_issue_raised(

--- a/tests/unit/phase/test_lookup.py
+++ b/tests/unit/phase/test_lookup.py
@@ -379,8 +379,13 @@ class TestEntityLookupPhase:
         # first org to resolve the entity wins
         assert output[0]["row"]["organisation"] == "local-authority:OE"
 
-    def test_multi_org_one_missing_raises_issue_and_emits_found(self):
-        # OE resolves, TB has no lookup -> one row for OE + one unknown-entity issue.
+    def test_multi_org_one_missing_emits_found_without_issue(self):
+        # OE resolves, TB has no lookup -> one row for OE and NO issue. A shared
+        # resource routinely holds one organisation's rows alongside another's,
+        # so a reference missing for the organisation that does not own it is
+        # normal. Issues carry no organisation and are fanned out to every
+        # organisation on the resource as tasks, so raising one here would tell
+        # both authorities their records were missing.
         input_stream = [
             {
                 "row": {
@@ -404,9 +409,9 @@ class TestEntityLookupPhase:
         assert len(output) == 1
         assert output[0]["row"]["entity"] == "101"
         assert output[0]["row"]["organisation"] == "local-authority:OE"
-        assert [i["issue-type"] for i in issues.rows] == ["unknown entity"]
+        assert issues.rows == []
 
-    def test_multi_org_neither_found_emits_nothing_and_raises_issues(self):
+    def test_multi_org_neither_found_emits_nothing_and_raises_one_issue(self):
         input_stream = [
             {
                 "row": {
@@ -428,11 +433,9 @@ class TestEntityLookupPhase:
         output = [block for block in phase.process(input_stream)]
 
         assert output == []
-        # one unknown-entity issue per organisation that missed
-        assert [i["issue-type"] for i in issues.rows] == [
-            "unknown entity",
-            "unknown entity",
-        ]
+        # nothing resolved at all, so one issue for the entry -- not one per
+        # organisation, which would fan out into a task for each of them
+        assert [i["issue-type"] for i in issues.rows] == ["unknown entity"]
 
     def test_multi_org_row_with_own_organisation_is_not_fanned_out(self):
         # Some collections map a source column to the organisation (e.g.

--- a/tests/unit/test_check.py
+++ b/tests/unit/test_check.py
@@ -110,6 +110,25 @@ def test_duplicate_reference_check(tmp_path):
             ],
         ),
         (
+            "different_entity.csv",
+            [
+                {
+                    "entity": 7010002598,
+                    "entry-date": "2024-07-19",
+                    "entry-number": 1,
+                    "field": "reference",
+                    "value": "ref1",
+                },
+                {
+                    "entity": 7010002599,
+                    "entry-date": "2024-07-19",
+                    "entry-number": 1,
+                    "field": "reference",
+                    "value": "ref1",
+                },
+            ],
+        ),
+        (
             "no_references.csv",
             [
                 {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Changing the way the pipeline generates entities from a resource in a situation where multiple endpoints **from different organisations** provide identical data and therefore produce the same resource.

Before - No entities are produced from resources with multiple orgs.
After - now generate entities per organisation per resource. 

## Why 

Because we are currently missing entities in our data and this is causing a bunch of problems particularly for local-plan data.

## How the bug works

A resource is identified only by the hash of its contents. When two organisations publish the same URL, they produce identical bytes, so the collection merges them into a **single resource that carries both organisation codes**.

To generate entities, the pipeline stamps a default organisation onto every row of a resource (most data files don't say which authority they belong to). But it only does this when there is exactly one organisation:

```python
if len(organisations) == 1:
    default_values["organisation"] = organisations[0]
```



## Worked example — South & Vale Joint Local Plan 2045

South Oxfordshire and Vale of White Horse jointly published one local plan timetable at a single URL:

`https://www.southandvale.gov.uk/app/uploads/2026/06/Local-Plan-Timetable-CSV.csv`

In `source.csv` that one endpoint was attributed to both authorities:

| organisation | dataset |
|---|---|
| `local-authority:SOX` | plan-timetable |
| `local-authority:VAL` | plan-timetable |

`lookup.csv` already defines separate entities for each authority against the same references, for example:

| dataset | reference | SOX entity | VAL entity |
|---|---|---|---|
| plan-timetable | `Joint-Local-Plan-2045-scoping-consultation-start` | 5110200 | 5110188 |

**Before:** the resource carries two organisations, the guard is skipped, and neither authority's entities are created — both show zero records supplied.

**After:** entity lookup resolves the reference once per organisation and emits a row per distinct entity, so both authorities get their entities.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com/digital-land/digital-land-python/issues/573)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings


### Tested in DEV

DEV's collected `resource.csv` has **4 active multi-org resources** (organisations column containing `;`). I tested by looking at this one:

|-|-|
|---|---|
| Resource | `ae8f59326ef53ede176817221ff512c00d3bc860874e8b8add2fb84dbc06e1f5` |
| Organisations | `local-authority:ADU;local-authority:WOT` (Adur + Worthing) |
| Endpoint | `ea98ea4d156ee47f…` |
| Dataset | brownfield-land |

Adur and Worthing publish a single shared brownfield-land CSV. 

#### Result — the fix works

- **743 fact rows, 45 distinct entities, 0 blank-entity rows**
- `local-authority:ADU` — 23 entities
- `local-authority:WOT` — 22 entities
- all rows `priority=2` (authoritative)

**Before the change this file was empty** — no organisation meant no entity, and every row was pruned. Both councils showed zero records supplied. Both councils' data is now created from the single shared resource.


### Why this is safer than it first looks

Changing how resources map to organisations sounds like it touches a core assumption, but the pipeline is already **entity-centric below the resource level** — facts, dataset assembly and tasks are all keyed on the entity, not the resource. So "process a resource once per organisation" fits the existing model rather than fighting it: each organisation resolves to its own entity, and from that point on everything treats the two organisations exactly as if they'd come from separate resources.

The load-bearing detail is that a fact's identity is a hash of `entity : field : value`, so two organisations producing identical rows still create distinct facts (different entities → different hashes). That's why nothing collapses or overwrites. I also confirmed the resource-level logs are set, not accumulated, so nothing double-counts.

The change is also naturally bounded: resources with one organisation (or none) follow exactly the same path as before — only resources with two or more organisations hit the new behaviour. Which is a relatively small subset of the total data.

### Impact on issues generated
an unknown-entity issue is raised only when no organisation resolves an entity

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of changes

* **New Features**
  * Entity lookups can now fan out across multiple organisations, stamping the resolved organisation onto both the output row and block.
  * If an input row already specifies its organisation, lookups respect it without fan-out.

* **Bug Fixes**
  * Duplicate reference detection is now evaluated separately per entity, and duplicate reports include the correct entity context.
  * “Unknown entity” handling is more consistent, including missing-reference cases, with only one issue raised when no organisations resolve.

* **Documentation**
  * Updated pipeline documentation to clarify how multi-organisation lookup behaves.

* **Tests**
  * Added unit coverage for multi-organisation fan-out, deduplication, and unknown-match scenarios, plus an extra duplicate-reference case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->