### PR TITLE
conditional fields expectation for local plans

### DIFF
--- a/digital_land/expectations/checkpoints/dataset.py
+++ b/digital_land/expectations/checkpoints/dataset.py
@@ -12,6 +12,7 @@ from digital_land.organisation import Organisation
 from .base import BaseCheckpoint
 from ..log import ExpectationLog
 from ..operations.dataset import (
+    check_fields_required_after_plan_event,
     count_lpa_boundary,
     count_deleted_entities,
     duplicate_geometry_check,
@@ -37,6 +38,7 @@ class DatasetCheckpoint(BaseCheckpoint):
             operation: a string representing an operation
         """
         operation_map = {
+            "check_fields_required_after_plan_event": check_fields_required_after_plan_event,
             "count_lpa_boundary": count_lpa_boundary,
             "count_deleted_entities": count_deleted_entities,
             "duplicate_geometry_check": duplicate_geometry_check,

--- a/digital_land/expectations/operations/dataset.py
+++ b/digital_land/expectations/operations/dataset.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import sqlite3
 import requests
@@ -5,6 +6,7 @@ import pandas as pd
 import urllib
 import os
 import time
+from datetime import datetime
 
 
 # # TODO is there a way to represent this in a generalised count or not
@@ -459,4 +461,99 @@ def duplicate_geometry_check(conn, spatial_field: str):
         "single_matches": single_matches,
         "any_matches": any_matches,
     }
+    return result, message, details
+
+
+def check_fields_required_after_plan_event(
+    conn,
+    fields: list,
+    plan_timetable_path: str,
+    plan_event: str = "proposed-plan-consultation-start",
+    today: str = None,
+):
+    """
+    Checks that a set of fields are populated on plan records, but only for plans
+    which have reached a given stage of plan making.
+
+    A plan reaches the stage when its linked plan-timetable row for plan_event has
+    an actual-date in the past. Plans which have not reached that stage are ignored,
+    so no issue is raised for data the LPA is not yet expected to supply.
+
+    The plan-timetable data lives in a different dataset, so it is fetched as a
+    published artifact during assemble and attached here as a second database.
+
+    args:
+        conn: connection to the dataset being checked, created by the checkpoint class
+        fields: the fields which must be populated once the stage is reached
+        plan_timetable_path: path to a local copy of the built plan-timetable sqlite
+        plan_event: the plan-timetable event which opens the gate
+        today: date to compare against as YYYY-MM-DD, defaults to the current date
+    """
+    if not fields:
+        raise ValueError("At least one field must be provided to check")
+
+    today = today or datetime.now().strftime("%Y-%m-%d")
+
+    # a missing timetable artifact must never fail the build, the check just can't run
+    if not plan_timetable_path or not os.path.isfile(plan_timetable_path):
+        message = (
+            f"plan-timetable not available at '{plan_timetable_path}', check skipped"
+        )
+        logging.warning(message)
+        return True, message, {"skipped": True, "failures": []}
+
+    # a plan can have more than one row for the same event, so take the earliest
+    # actual-date, the stage is reached as soon as any of them has passed
+    query = """
+        select
+            e.reference,
+            e.json,
+            e.organisation_entity,
+            min(json_extract(t.json, '$."actual-date"')) as actual_date
+        from entity e
+        inner join plan_timetable.entity t
+            on json_extract(t.json, '$.plan') = e.reference
+        where json_extract(t.json, '$."plan-event"') = ?
+            and coalesce(json_extract(t.json, '$."actual-date"'), '') != ''
+            and json_extract(t.json, '$."actual-date"') < ?
+        group by e.entity
+    """
+
+    conn.execute("ATTACH DATABASE ? AS plan_timetable", (str(plan_timetable_path),))
+    try:
+        rows = conn.execute(query, (plan_event, today)).fetchall()
+    finally:
+        conn.execute("DETACH DATABASE plan_timetable")
+
+    failures = []
+    for reference, entity_json, organisation_entity, actual_date in rows:
+        entity_fields = json.loads(entity_json or "{}")
+        for field in fields:
+            value = entity_fields.get(field)
+            if value is not None and str(value).strip():
+                continue
+            failures.append(
+                {
+                    "organisation": entity_fields.get("organisations") or "",
+                    "organisation_entity": organisation_entity,
+                    "reference": reference,
+                    "field": field,
+                    "actual-date": actual_date,
+                }
+            )
+
+    failures.sort(key=lambda failure: (failure["reference"], failure["field"]))
+
+    result = len(failures) == 0
+    message = (
+        f"{len(failures)} missing values found across {len(rows)} plans "
+        f"which have passed {plan_event}"
+    )
+    details = {
+        "failures": failures,
+        "fields": fields,
+        "plan_event": plan_event,
+        "plans_past_event": len(rows),
+    }
+
     return result, message, details

--- a/tests/integration/expectations/operations/test_dataset.py
+++ b/tests/integration/expectations/operations/test_dataset.py
@@ -1,3 +1,4 @@
+import json
 import spatialite
 import sqlite3
 import pytest
@@ -5,6 +6,7 @@ import pandas as pd
 
 from digital_land.expectations.operations.dataset import (
     check_columns,
+    check_fields_required_after_plan_event,
     count_lpa_boundary,
     count_deleted_entities,
     duplicate_geometry_check,
@@ -567,3 +569,156 @@ def test_duplicate_geometry_check_no_dupes(dataset_path):
     assert not details["any_matches"]
     assert details["actual"] == 0
     assert details["expected"] == 0
+
+
+@pytest.fixture
+def plan_timetable_path(tmp_path):
+    """a minimal built plan-timetable sqlite, matching the dataset entity schema"""
+    plan_timetable_path = tmp_path / "plan-timetable.sqlite3"
+    with spatialite.connect(plan_timetable_path) as con:
+        con.execute(
+            """
+            CREATE TABLE entity (
+                entity INTEGER PRIMARY KEY,
+                json JSON,
+                reference TEXT
+            );
+        """
+        )
+        rows = [
+            # consultation started in the past, this plan is gated on
+            (1, "started-plan", "proposed-plan-consultation-start", "2024-12-12"),
+            # a duplicate row for the same event, the earliest date should win
+            (2, "started-plan", "proposed-plan-consultation-start", "2025-01-30"),
+            # consultation only planned, no actual-date, so not gated on
+            (3, "future-plan", "proposed-plan-consultation-start", ""),
+            # a different event which must not open the gate
+            (4, "other-event-plan", "scoping-consultation-start", "2020-01-01"),
+        ]
+        for entity, plan, plan_event, actual_date in rows:
+            con.execute(
+                "INSERT INTO entity (entity, json, reference) VALUES (?, ?, ?)",
+                (
+                    entity,
+                    json.dumps(
+                        {
+                            "plan": plan,
+                            "plan-event": plan_event,
+                            "actual-date": actual_date,
+                        }
+                    ),
+                    f"{plan}-{plan_event}",
+                ),
+            )
+    return plan_timetable_path
+
+
+def test_check_fields_required_after_plan_event(dataset_path, plan_timetable_path):
+    plans = [
+        # past consultation start with a blank field, should be flagged
+        (1, "started-plan", {"organisations": "local-authority:EXE"}),
+        # past consultation start but populated, should not be flagged
+        (2, "started-plan-complete", {"organisations": "local-authority:ARU"}),
+        # not yet consulted, blank is fine, should not be flagged
+        (3, "future-plan", {"organisations": "local-authority:CMD"}),
+        # wrong event, blank is fine, should not be flagged
+        (4, "other-event-plan", {"organisations": "local-authority:ISL"}),
+    ]
+    with spatialite.connect(dataset_path) as con:
+        for entity, reference, fields in plans:
+            if reference == "started-plan-complete":
+                fields = {**fields, "period-end-date": "2042-01-01"}
+            con.execute(
+                "INSERT INTO entity (entity, reference, organisation_entity, json)"
+                " VALUES (?, ?, ?, ?)",
+                (entity, reference, str(entity), json.dumps(fields)),
+            )
+
+    # started-plan-complete has no timetable row, give it one that has started
+    with spatialite.connect(plan_timetable_path) as con:
+        con.execute(
+            "INSERT INTO entity (entity, json, reference) VALUES (?, ?, ?)",
+            (
+                5,
+                json.dumps(
+                    {
+                        "plan": "started-plan-complete",
+                        "plan-event": "proposed-plan-consultation-start",
+                        "actual-date": "2024-01-01",
+                    }
+                ),
+                "started-plan-complete-proposed-plan-consultation-start",
+            ),
+        )
+
+    with spatialite.connect(dataset_path) as con:
+        passed, message, details = check_fields_required_after_plan_event(
+            conn=con,
+            fields=["period-end-date"],
+            plan_timetable_path=plan_timetable_path,
+            today="2026-08-10",
+        )
+
+    assert not passed, message
+    assert details["plans_past_event"] == 2
+    assert details["failures"] == [
+        {
+            "organisation": "local-authority:EXE",
+            "organisation_entity": "1",
+            "reference": "started-plan",
+            "field": "period-end-date",
+            "actual-date": "2024-12-12",
+        }
+    ]
+
+
+def test_check_fields_required_after_plan_event_missing_timetable(
+    dataset_path, tmp_path
+):
+    """a missing artifact must skip the check, never fail the build"""
+    with spatialite.connect(dataset_path) as con:
+        passed, message, details = check_fields_required_after_plan_event(
+            conn=con,
+            fields=["period-end-date"],
+            plan_timetable_path=tmp_path / "does-not-exist.sqlite3",
+        )
+
+    assert passed
+    assert details["skipped"] is True
+    assert "check skipped" in message
+
+
+def test_check_fields_required_after_plan_event_null_value(
+    dataset_path, plan_timetable_path
+):
+    """an explicit null must count as missing, not as populated"""
+    with spatialite.connect(dataset_path) as con:
+        con.execute(
+            "INSERT INTO entity (entity, reference, organisation_entity, json)"
+            " VALUES (?, ?, ?, ?)",
+            (
+                1,
+                "started-plan",
+                "1",
+                json.dumps({"organisations": None, "period-end-date": None}),
+            ),
+        )
+
+    with spatialite.connect(dataset_path) as con:
+        passed, message, details = check_fields_required_after_plan_event(
+            conn=con,
+            fields=["period-end-date"],
+            plan_timetable_path=plan_timetable_path,
+            today="2026-08-10",
+        )
+
+    assert not passed, message
+    assert details["failures"] == [
+        {
+            "organisation": "",
+            "organisation_entity": "1",
+            "reference": "started-plan",
+            "field": "period-end-date",
+            "actual-date": "2024-12-12",
+        }
+    ]


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds a new dataset expectation, `check_fields_required_after_plan_event`, which checks that a three specific fields are populated on plan records — but only for plans that have actually reached the stage where those fields become required. 

A plan reaches that stage when its linked `plan-timetable` row for `proposed-plan-consultation-start` has an `actual-date` in the past. 

**This change is inert on merge** — the operation only runs once a matching rule is added to `expect.csv`, which is a later step. 

## Why

We used to flag these fields as "missing value" whenever they were blank, producing false positives on the LPA Dashboard — LPAs were asked for data they weren't yet expected to supply. Part 1 of the ticket removed those checks, which stopped the false positives but left no check at all. This restores it, gated on the plan's actual progress.

It's an expectation rather than an issue because the gate lives in a different dataset from the fields being checked. Issues are raised per-resource during processing and can't see across datasets; expectations run after the data is built, so the comparison is straightforward.

 Only one plan has passed `proposed-plan-consultation-start` with a recorded `actual-date`, and it's fully populated — most LPAs have that consultation scheduled for 2027-28. So this is really work that all about getting our systems ready for data that we expect to exist in the future.


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com/digital-land/submit/issues/1187)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

This change is inert on merge: the new operation is only ever reached by name from a rule in `expect.csv`, and no rule references it yet — across all 55 `expect.csv` files in config, only `count_deleted_entities`, `count_lpa_boundary` and `duplicate_geometry_check` are used.

Nothing will run, and no builds change behaviour. 

After this has been merged I will make a PR for config repo and for collection-task do some testing from there in DEV.


## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
