### PR TITLE
fix: make file donwload atomic

### DIFF
--- a/digital_land/api.py
+++ b/digital_land/api.py
@@ -3,6 +3,7 @@ from enum import Enum
 import os
 import requests
 import logging
+import tempfile
 import typing
 
 from digital_land.pipeline.main import Pipeline
@@ -54,30 +55,30 @@ class API:
             logging.info(f"Dataset file {path} already exists.")
             return
 
-        # different extensions require different urls and reading modes
+        # different extensions require different urls
         if extension == self.Extension.SQLITE3:
             collection = self.specification.dataset[dataset]["collection"]
             url = f"{self.url}/{collection}-collection/dataset/{dataset}.sqlite3"
-            mode = "wb"
-
-            def get_content(response):
-                return (
-                    response.content
-                )  # need binary content otherwise .sqlite3 is corrupted
-
         else:
             url = f"{self.url}/dataset/{dataset}.csv"
-            mode = "w"
-
-            def get_content(response):
-                return response.text
 
         response = requests.get(url)
         response.raise_for_status()
 
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        with open(path, mode) as f:
-            f.write(get_content(response))
+        directory = os.path.dirname(path)
+        os.makedirs(directory, exist_ok=True)
+
+        # Write to a temporary file in the same directory, then rename it into
+        # place. os.replace is atomic, so other processes only ever see a
+        # complete file - never one that is empty or half-written.
+        fd, tmp_path = tempfile.mkstemp(dir=directory, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "wb") as f:
+                f.write(response.content)
+            os.replace(tmp_path, path)
+        except BaseException:
+            os.unlink(tmp_path)
+            raise
 
         logging.info(f"Downloaded dataset {dataset} from {url} to {path}")
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -72,34 +72,37 @@ def _mock_get(status_code, content, calls=[]):
     return _mocked_get
 
 
-def test_download_dataset_cache(mocker):
+def test_download_dataset_cache(mocker, tmp_path):
     mocker.patch("requests.get", _mock_get(200, _tpz_type_data))
-    mocker.patch("builtins.open", mock_open())
-    mocker.patch("os.makedirs", Mock())
 
-    api = API(Mock(), "http://test", "/test/cache-dir")
+    api = API(Mock(), "http://test", str(tmp_path))
 
     api.download_dataset("test")
 
+    written = list((tmp_path / "dataset").iterdir())
+    assert len(written) == 1, "a temporary file was left behind"
+    assert written[0].read_bytes() == _tpz_type_data
 
-def test_download_dataset_specified(mocker):
+
+def test_download_dataset_specified(mocker, tmp_path):
     mocker.patch("requests.get", _mock_get(200, _tpz_type_data))
-    mocker.patch("builtins.open", mock_open())
-    mocker.patch("os.makedirs", Mock())
+    path = tmp_path / "test.csv"
 
-    api = API(Mock(), "http://test", "/test/cache-dir")
+    API(Mock(), "http://test", str(tmp_path)).download_dataset("test", path=str(path))
 
-    api.download_dataset("test", path="test.csv")
+    assert path.read_bytes() == _tpz_type_data
 
 
-def test_download_dataset_overwrite(mocker):
+def test_download_dataset_overwrite(mocker, tmp_path):
     mocker.patch("requests.get", _mock_get(200, _tpz_type_data))
-    mocker.patch("builtins.open", mock_open())
-    mocker.patch("os.makedirs", Mock())
+    path = tmp_path / "test.csv"
+    path.write_bytes(b"stale")
 
-    api = API(Mock(), "http://test", "/test/cache-dir")
+    API(Mock(), "http://test", str(tmp_path)).download_dataset(
+        "test", overwrite=True, path=str(path)
+    )
 
-    api.download_dataset("test", overwrite=True, path="test.csv")
+    assert path.read_bytes() == _tpz_type_data
 
 
 def test_download_dataset_error(mocker):
@@ -112,24 +115,23 @@ def test_download_dataset_error(mocker):
         api.download_dataset("test")
 
 
-def test_get_categorical_field_values_download(mocker, pipeline_dir):
+def test_get_categorical_field_values_download(mocker, pipeline_dir, tmp_path):
     get_calls = []
     mocker.patch("requests.get", _mock_get(200, _tpz_type_data, get_calls))
-    mocker.patch("builtins.open", mock_open(read_data=_tpz_type_data.decode("ascii")))
-    mocker.patch("os.makedirs", Mock())
-    mocker.patch("os.path.exists", Mock(return_value=False))
-    mocker.patch("os.stat", Mock(return_value=_stat_result_tpzt))
 
     pipeline = Pipeline(pipeline_dir, "tree-preservation-zone")
 
-    api = API(MockSpecification(), "http://test", "/test/cache-dir")
+    api = API(MockSpecification(), "http://test", str(tmp_path))
 
     values = api.get_valid_category_values("tree-preservation-zone", pipeline)
 
     assert len(get_calls) == 1
     assert get_calls[0] == "http://test/dataset/tree-preservation-zone-type.csv"
-
     assert values == {"tree-preservation-zone-type": ["area", "group", "woodland"]}
+
+    # prove the download actually landed, rather than the fallback empty file
+    cached = tmp_path / "dataset" / "tree-preservation-zone-type.csv"
+    assert cached.read_bytes() == _tpz_type_data
 
 
 def test_get_categorical_field_from_cache(mocker, pipeline_dir):


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`API.download_dataset` now writes the downloaded file to a temporary file in the target directory and renames it into place with `os.replace`, rather than writing straight to the final path with `open(path, "w")`. It also writes `response.content` (raw bytes) instead of `response.text`, which removes the need for the separate CSV/SQLite content and mode handling.

## Why

`get_valid_category_values` runs once per resource, and transform runs 8 worker processes in parallel, so on a cold cache all 8 check for the cached dataset CSV, all find it missing, and all download it. Because `open(path, "w")` empties the file in place before rewriting it, a straggler finishing its HTTP request could blank the file while another worker was part-way through reading it.

Usually that just returned a short list of valid category values, which logs false "invalid category value" issues against perfectly valid data. Occasionally the truncation landed mid-character and killed the container with `'utf-8' codec can't decode byte 0xc3 in position 0: unexpected end of data`, which is what has been failing the article-4-direction-area transform task. Those `0xc3` bytes only existed because the CDN serves `text/csv` with no charset, so `requests` falls back to ISO-8859-1 and `response.text` double-encoded every non-ASCII character on the way to disk.

After the change a reader only ever sees a complete file: the rename is atomic, and a worker holding the old file open keeps reading it intact. Verified with 8 workers racing a cold cache through the real code path — 40/40 got the full category list, against 100/320 degraded reads with the previous pattern.


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com/digital-land/config/issues/2865)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

## Testing

`tests/acceptance/test_pipeline_real_transform.py` passes (15 tests). That is the most useful existing coverage here because it downloads real resources from `files.planning.data.gov.uk` and runs real transforms against them, including an `article-4-direction-area` resource, so the changed download path is exercised end to end rather than in isolation.

The behaviour this fixes is a race, so it was tested directly: 8 worker processes were pointed at a cold cache and run through the real `API.get_valid_category_values` code path for `article-4-direction-area`, five times over. All 40 workers returned the complete 240-value category list with no exceptions. The same test against the previous write pattern produced 100 degraded reads out of 320. The original production failure was also reproduced beforehand — feeding the real cached file content through `csv.DictReader` while another process truncated it gives back the exact production error string, byte for byte — so we know the fix is aimed at the actual cause rather than a plausible-looking one.

### Local Paranoia check

I picked 5 datasets which donwload csvs and check they ran fine:


| Dataset | Category fields | Workers | Result |
|---|---|---|---|
| `article-4-direction-area` | 1 (the file causing the failures) | 40 | 40/40 complete, 0 exceptions |
| `brownfield-land` | 6 (mix of published and 404) | 40 | 40/40 identical, 0 exceptions |
| `flood-risk-zone` | 2 (both published) | 24 | 24/24 identical, 0 exceptions |
| `conservation-area-document` | 1 | 24 | 24/24 identical, 0 exceptions |
| `listed-building` | 1 | 24 | 24/24 identical, 0 exceptions |

152 workers across 19 cold-cache rounds in total.



## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dataset downloads by writing files safely and atomically, reducing the risk of incomplete or corrupted files.
  * Temporary download files are now cleaned up if saving fails.
  * Existing files continue to be preserved unless overwrite is explicitly enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->